### PR TITLE
Added dirty editor tracking and a warning before user leaves the page with unsaved changes

### DIFF
--- a/js/addlisteners.js
+++ b/js/addlisteners.js
@@ -13,3 +13,19 @@ if (el.addEventListener) {
     el.attachEvent('onmousemove', mouseMove);
     el.attachEvent('onmouseout', mouseOut);
 }  
+
+window.onbeforeunload = function (e) {
+	var e = e || window.event;
+	var msg = 'You have unsaved changes!';
+
+	if(_editorDirty) {			
+
+		// For IE and Firefox prior to version 4
+		if (e) {
+			e.returnValue = msg;
+		}
+
+		// For Safari
+		return msg;
+	}
+};

--- a/js/editor.js
+++ b/js/editor.js
@@ -1,4 +1,5 @@
 var code = document.getElementById('code');
+var _editorDirty = false;
 
 var fileToOpen=getParameterByName("demo");
 if (fileToOpen!==null&&fileToOpen.length>0) {
@@ -38,6 +39,18 @@ editor.on('mousedown', function(cm, event) {
       compile(["levelline",cm.posFromMouse(event).line]);      
     }
   }
+});
+
+editor.on('change', function(cm, changeObj) {
+
+	// editor is dirty
+	_editorDirty = true;
+
+	var saveLink = document.getElementById('saveClickLink');
+	if(saveLink) {
+		saveLink.innerHTML = 'SAVE*';
+	}
+
 });
 
 var mapObj = {
@@ -119,3 +132,4 @@ function dropdownChange() {
 	tryLoadFile(this.value);
 	this.selectedIndex=0;
 }
+

--- a/js/toolbar.js
+++ b/js/toolbar.js
@@ -45,6 +45,12 @@ function saveClick() {
 	var loadDropdown = document.getElementById('loadDropDown');
 	loadDropdown.selectedIndex=0;
 
+	var saveLink = document.getElementById('saveClickLink');
+	if(saveLink) {
+		saveLink.innerHTML = 'SAVE';
+	}
+	_editorDirty = false;
+
 	consolePrint("saved file to local storage");
 }
 


### PR DESCRIPTION
Not sure if you're accepting pull requests yet (or ever).  I've implemented a basic dirty indicator to the editor, and a warning prompt if the user attempts to leave the page with unsaved changed.  Only tested on Mac version of Chrome, Safari and Firefox.
