### PR TITLE
Move Menu Tab/Slider, Repeat movement w/ long swipe

### DIFF
--- a/js/mobile.js
+++ b/js/mobile.js
@@ -114,6 +114,7 @@ Mobile.debugDot = function (event) {
         if (!this.isAudioSupported()) {
             this.disableAudio();
         }
+        this.disableSelection();
     };
 
     /** Event Handlers **/
@@ -537,6 +538,14 @@ Mobile.debugDot = function (event) {
 
         return isAudioSupported;
     };
+
+    /** Other HTML5 Stuff **/
+    proto.disableSelection = function () {
+        var body;
+        body = document.getElementsByTagName('body')[0];
+        body.setAttribute('class', body.getAttribute('class') + ' disable-select');
+    };
+
 }(window.Mobile.GestureHandler.prototype));
 
 window.Animator = function () {

--- a/play.html
+++ b/play.html
@@ -168,6 +168,14 @@ a {
           }
       }
 
+     .disable-select {
+         -webkit-touch-callout: none;
+         -webkit-user-select: none;
+         -khtml-user-select: none;
+         -moz-user-select: none;
+         -ms-user-select: none;
+         user-select: none;
+     }
 
 </style>
 <meta name="viewport" content="width=device-width, initial-scale=1, maximum-scale=1">


### PR DESCRIPTION
This PR has a few small things:
- Menu tab/slider move lower, about to the top of the Canvas element
- If you swipe and leave your finger down, movement will be repeated at a rate of 3 times per second.
- You can also change directions while movement is repeating
