### PR TITLE
Enable touch interface in the editor

### DIFF
--- a/css/gamecanvas.css
+++ b/css/gamecanvas.css
@@ -10,3 +10,13 @@
   border: 0px;
   background-color: black;
 } 
+
+.tapFocusIndicator {
+    color: white;
+    position: absolute;
+    border: 3px solid gray;
+    left: 0px;
+    right: 0px;
+    top: 0px;
+    bottom: 0px;
+}

--- a/js/addlisteners_editor.js
+++ b/js/addlisteners_editor.js
@@ -57,3 +57,8 @@ window.onbeforeunload = function (e) {
     return msg;
   }
 };
+
+var gestureHandler = Mobile.enable();
+if (gestureHandler) {
+    gestureHandler.setFocusElement(document.getElementById('gameCanvas'));
+}


### PR DESCRIPTION
Swipe gestures are enabled when the touch begins within the game canvas. This does not include the popout menu since the compile/run commands roughly correspond to the same actions.
