### PR TITLE
Added testsAutoAdvanceLevel flag.

### DIFF
--- a/js/engine.js
+++ b/js/engine.js
@@ -2403,7 +2403,7 @@ function DoWin() {
 	}
 	againing=false;
 	tryPlayEndLevelSound();
-	if (unitTesting) {
+	if (unitTesting && testsAutoAdvanceLevel) {
 		nextLevel();
 		return;
 	}

--- a/js/globalVariables.js
+++ b/js/globalVariables.js
@@ -1,4 +1,5 @@
 var unitTesting=false;
+var testsAutoAdvanceLevel=true;
 var curlevel=0;
 var levelEditorOpened=false;
 


### PR DESCRIPTION
Sometimes, you might want to write a unit test that stays at the winning state before progressing to the next level, so you can e.g. make sure that the winning state has various desired properties. Or you might want to automatically find a solution to the level without advancing to the next level. This small change makes that possible (but keeps the current behavior as a default).
