### PR TITLE
Don't use hasOwnProperty to detect ontouchstart

### DIFF
--- a/js/mobile.js
+++ b/js/mobile.js
@@ -6,7 +6,7 @@ window.Mobile = {};
 
 Mobile.hasTouch = function() {
     return document.documentElement &&
-        document.documentElement.hasOwnProperty('ontouchstart');
+        document.documentElement.ontouchstart !== undefined;
 };
 
 Mobile.enable = function (force) {


### PR DESCRIPTION
document.documentElement.hasOwnProperty('ontouchstart') was returning false on iOS 8.