### PR TITLE
Ignore keypresses when ctrl or alt is pressed.

### DIFF
--- a/js/inputoutput.js
+++ b/js/inputoutput.js
@@ -492,6 +492,10 @@ function checkKey(e,justPressed) {
     if (winning) {
     	return;
     }
+    if (e.ctrlKey || e.metaKey || e.altKey) {
+        // This may be a keyboard shortcut for the browser.
+        return;
+    }
     var inputdir=-1;
     switch(e.keyCode) {
         case 65://a


### PR DESCRIPTION
For issue #51. This commit is licensed as MIT/X11.

This fixes it for me (Firefox 38.0 on Ubuntu 14.10). I don't think it's worth doing something more fine-tuned, since none of the normal in-game commands handled by checkKey require modifiers, and who knows which of them will collide with browser shortcuts. There are modifier commands elsewhere, which shouldn't be affected.
