### PR TITLE
Allow cancel/restart sound effects and messages.

### DIFF
--- a/Documentation/sounds.html
+++ b/Documentation/sounds.html
@@ -160,6 +160,9 @@ here are the possible sound events declarations
 <dt><b>Undo</b> 123413</dt>
 <dd>Played when the player presses the undo button (Z).</dd>
 
+<dt><b>Cancel</b> 123413</dt>
+<dd>Played when a rule triggers the CANCEL command.</dd>
+
 </dl>
 <b>move</b> and <b>cantmove</b> can be supplied with directions, so that certain sounds play if you move in particular directions.  
    

--- a/js/compiler.js
+++ b/js/compiler.js
@@ -482,6 +482,7 @@ var simpleRelativeDirections = ['^', 'v', '<', '>'];
 var reg_directions_only = /^(\>|\<|\^|v|up|down|left|right|moving|stationary|no|randomdir|random|horizontal|vertical|orthogonal|perpendicular|parallel|action)$/;
 //redeclaring here, i don't know why
 var commandwords = ["sfx0","sfx1","sfx2","sfx3","sfx4","sfx5","sfx6","sfx7","sfx8","sfx9","sfx10","cancel","checkpoint","restart","win","message","again"];
+var resetExtraCommands = ["sfx0","sfx1","sfx2","sfx3","sfx4","sfx5","sfx6","sfx7","sfx8","sfx9","sfx10","message"];
 
 
 
@@ -743,17 +744,25 @@ function processRuleString(rule, state, curRules)
 		rule_line.directions=['up'];
 	}
 
-	/* reset must appear by itself */
+	/* reset must appear first, and can only be used with certain other rules */
 
-	for (var i=0;i<commands.length;i++) {
+	for (var i=1;i<commands.length;i++) {
 		var cmd = commands[i][0];
-		if (cmd==='restart') {
-			if (commands.length>1 || rhs_cells.length>0) {
-				logError('The RESTART command can only appear by itself on the right hand side of the arrow.', lineNumber);
-			}
-		} else if (cmd==='cancel') {
-			if (commands.length>1 || rhs_cells.length>0) {
-				logError('The CANCEL command can only appear by itself on the right hand side of the arrow.', lineNumber);
+		if (cmd==='restart' || cmd==='cancel') {
+			logError('The '+cmd+' command can only appear immediately to the right of the arrow.', lineNumber);
+		}
+	}
+
+	if (commands.length>0 && (commands[0][0]==='restart' || commands[0][0]==='cancel'))
+	{
+		var resetCmd = commands[0][0];
+		if (rhs_cells.length>0) {
+			logError('The '+resetCmd+' command can only appear immediately to the right of the arrow.', lineNumber);
+		}
+		for (var i=1;i<commands.length;i++) {
+			var cmd = commands[i][0];
+			if (resetExtraCommands.indexOf(cmd) === -1) {
+				logError('The '+resetCmd+' command can only appear by itself on the right hand side of the arrow, or with a message or sound effect.', lineNumber);
 			}
 		}
 	}

--- a/js/compiler.js
+++ b/js/compiler.js
@@ -2118,7 +2118,7 @@ function generateLoopPoints(state) {
 	state.lateLoopPoint=loopPoint;
 }
 
-var soundEvents = ["titlescreen", "startgame", "endgame", "startlevel","undo","restart","endlevel","showmessage","closemessage","sfx0","sfx1","sfx2","sfx3","sfx4","sfx5","sfx6","sfx7","sfx8","sfx9","sfx10"];
+var soundEvents = ["titlescreen", "startgame", "endgame", "startlevel","undo","cancel","restart","endlevel","showmessage","closemessage","sfx0","sfx1","sfx2","sfx3","sfx4","sfx5","sfx6","sfx7","sfx8","sfx9","sfx10"];
 var soundMaskedEvents =["create","destroy","move","cantmove","action"];
 var soundVerbs = soundEvents.concat(soundMaskedEvents);
 

--- a/js/engine.js
+++ b/js/engine.js
@@ -1895,6 +1895,20 @@ function showTempMessage() {
 	canvasResize();
 }
 
+function processOutputCommands(commands) {
+	for (var i=0;i<commands.length;i++) {
+		var command = commands[i];
+		if (command.charAt(1)==='f')  {//identifies sfxN
+			tryPlaySimpleSound(command);
+		}
+		if (unitTesting===false) {
+			if (command==='message') {
+				showTempMessage();
+			}
+		}
+	}
+}
+
 function applyRandomRuleGroup(ruleGroup) {
 	var propagated=false;
 
@@ -2202,6 +2216,7 @@ function processInput(dir,dontCheckWin,dontModify) {
 	    		consolePrint('CANCEL command executed, cancelling turn.');
 	    		consoleCacheDump();
 			}
+			processOutputCommands(level.commandQueue);
     		backups.push(bak);
     		DoUndo(true);
     		tryPlayCancelSound();
@@ -2213,6 +2228,7 @@ function processInput(dir,dontCheckWin,dontModify) {
 	    		consolePrint('RESTART command executed, reverting to restart state.');
 	    		consoleCacheDump();
 			}
+			processOutputCommands(level.commandQueue);
     		backups.push(bak);
 	    	DoRestart(true);
     		return true;
@@ -2271,17 +2287,7 @@ function processInput(dir,dontCheckWin,dontModify) {
         	}
         }
 
-	    for (var i=0;i<level.commandQueue.length;i++) {
-	 		var command = level.commandQueue[i];
-	 		if (command.charAt(1)==='f')  {//identifies sfxN
-	 			tryPlaySimpleSound(command);
-	 		}  	
-			if (unitTesting===false) {
-				if (command==='message') {
-					showTempMessage();
-				}
-			}
-	    }
+		processOutputCommands(level.commandQueue);
 
 	    if (textMode===false && (dontCheckWin===undefined ||dontCheckWin===false)) {
 	    	if (verbose_logging) { 

--- a/js/engine.js
+++ b/js/engine.js
@@ -474,6 +474,10 @@ function tryPlayUndoSound(){
 	tryPlaySimpleSound("undo");
 }
 
+function tryPlayCancelSound(){
+	tryPlaySimpleSound("cancel");
+}
+
 function tryPlayRestartSound(){
 	tryPlaySimpleSound("restart");
 }
@@ -2200,6 +2204,7 @@ function processInput(dir,dontCheckWin,dontModify) {
 			}
     		backups.push(bak);
     		DoUndo(true);
+    		tryPlayCancelSound();
     		return false;
 	    } 
 

--- a/js/parser.js
+++ b/js/parser.js
@@ -166,7 +166,7 @@ var codeMirrorFn = function() {
     var reg_equalsrow = /[\=]+/;
     var reg_notcommentstart = /[^\(]+/;
     var reg_csv_separators = /[ \,]*/;
-    var reg_soundverbs = /(move|action|create|destroy|cantmove|undo|restart|titlescreen|startgame|endgame|startlevel|endlevel|showmessage|closemessage|sfx0|sfx1|sfx2|sfx3|sfx4|sfx5|sfx6|sfx7|sfx8|sfx9|sfx10)\s+/;
+    var reg_soundverbs = /(move|action|create|destroy|cantmove|undo|cancel|restart|titlescreen|startgame|endgame|startlevel|endlevel|showmessage|closemessage|sfx0|sfx1|sfx2|sfx3|sfx4|sfx5|sfx6|sfx7|sfx8|sfx9|sfx10)\s+/;
     var reg_directions = /^(action|up|down|left|right|\^|v|\<|\>|forward|moving|stationary|parallel|perpendicular|horizontal|orthogonal|vertical|no|randomdir|random)$/;
     var reg_loopmarker = /^(startloop|endloop)$/;
     var reg_ruledirectionindicators = /^(up|down|left|right|horizontal|vertical|orthogonal|late|rigid)$/;


### PR DESCRIPTION
For issue #61.

This adds a "cancel" sound trigger, and loosens the restriction on combining other commands with cancel and restart.

Incidentally, the documentation (rules.html) already claims you can combine cancel with a sound effect in this way.
