### PR TITLE
Add "X to select" message if noaction.

### DIFF
--- a/js/engine.js
+++ b/js/engine.js
@@ -201,7 +201,7 @@ function generateTitleScreen()
 		titleImage[11]=".Z to undo.....................";
 	}
 	if (noAction) {
-		titleImage[10]="..................................";
+		titleImage[10]=".X to select......................";
 	}
 	for (var i=0;i<titleImage.length;i++)
 	{


### PR DESCRIPTION
Avoids the case where a person unfamiliar with PuzzleScript doesn't know
how to select an option from the menu.