### PR TITLE
Synonym confusion in parser

### DIFF
--- a/js/parser.js
+++ b/js/parser.js
@@ -838,7 +838,7 @@ var codeMirrorFn = function() {
                                         }
                                     }
                                     if (ok) {
-                                        var newlegend = [splits[0], splits[2].toLowerCase(), splits[4].toLowerCase()];
+                                        var newlegend = [splits[0]].concat(substitutor(splits[2])).concat(substitutor(splits[4]));
                                         for (var i = 6; i < splits.length; i += 2) {
                                             newlegend.push(splits[i].toLowerCase());
                                         }

--- a/js/parser.js
+++ b/js/parser.js
@@ -651,7 +651,7 @@ var codeMirrorFn = function() {
                                 for (var i=0;i<state.legend_synonyms.length;i++) {
                                     var a = state.legend_synonyms[i];
                                     if (a[0]===n) {           
-                                        return [a[1]];         
+                                        return substitutor(a[1]);
                                     }
                                 }
 
@@ -767,7 +767,7 @@ var codeMirrorFn = function() {
 	                                	for (var i=0;i<state.legend_synonyms.length;i++) {
 	                                		var a = state.legend_synonyms[i];
 	                                		if (a[0]===n) {   
-	                                			return [1];        
+	                                			return substitutor(a[1]);
 	                                		}
 	                                	}
 	                                	for (var i=0;i<state.legend_aggregates.length;i++) {
@@ -812,7 +812,7 @@ var codeMirrorFn = function() {
 	                                	for (var i=0;i<state.legend_synonyms.length;i++) {
 	                                		var a = state.legend_synonyms[i];
 	                                		if (a[0]===n) {   
-	                                			return [1];        
+	                                			return substitutor(a[1]);
 	                                		}
 	                                	}
 	                                	for (var i=0;i<state.legend_aggregates.length;i++) {

--- a/tests/resources/testdata.js
+++ b/tests/resources/testdata.js
@@ -492,6 +492,10 @@ var testdata = [
 	[
 		"Rigid weirdness test (#369)",
 		["title Rigid Clothes\nauthor ThatScar\n\nverbose_logging\ndebug\n\n========\nOBJECTS\n========\n\nBackground .\nLightGreen Green\n11111\n01111\n11101\n11111\n10111\n\nPlayer \nBlack Orange\n.000.\n.111.\n11111\n.111.\n.1.1.\n\nSumo A\nPink White\n..0..\n00000\n.000.\n.111.\n.0.0.\n\nShirt T\nWhite\n.....\n.....\n00000\n.000.\n.....\n\nPants U\nBlue\n.....\n.....\n.....\n.000.\n.0.0.\n\n=======\nLEGEND\n=======\n\nClothes = Shirt or Pants\nP = Player and Shirt and Pants\n\n=======\nSOUNDS\n=======\n\nplayer action 1232\n\n================\nCOLLISIONLAYERS\n================\n\nBackground\nPlayer, Sumo\nShirt\nPants\n\n======\nRULES\n======\n\n[ Parallel Player | Sumo ] -> [ Parallel Player | Parallel Sumo ]\n\nRigid [ Moving Player Clothes ] -> [ Moving Player Moving Clothes ]\n\n==============\nWINCONDITIONS\n==============\n\n=======\nLEVELS\n=======\n\nPA.\n\n",[3],"background:0,background pants player shirt:1,background sumo:2,\n",0,"1487773403601.2908"]
+	],
+	[
+		"Synonym confusion",
+		["title Simple Block Pushing Game\nauthor Stephen Lavelle\nhomepage www.puzzlescript.net\n\n========\nOBJECTS\n========\n\nBackground\nRed\n\nPlayer\nOrange\n\nFloorB2\nYellow\n\nFloorB1\nGreen\n\nFloorMain\nBlue\n\n=======\nLEGEND\n=======\n\nFloorB2AndDown = FloorB2\nFloorB1AndDown = FloorB1 and FloorB2AndDown\nFloorMainAndDown = FloorMain and FloorB1AndDown\n\n. = Background\nP = Player\n\n=======\nSOUNDS\n=======\n\n================\nCOLLISIONLAYERS\n================\n\nBackground\nFloorB2\nFloorB1\nFloorMain, Player\n\n======\nRULES\n======\n\n==============\nWINCONDITIONS\n==============\n\nno Player\n\n=======\nLEVELS\n=======\n\n...\n..P\n",[1],"background:0,0,0,\nbackground player:1,0,0,\n",0,"1496933845000"]
 	]
 ];
 


### PR DESCRIPTION
This fixes several closely-connected issues with the parser (for the most part involving synonyms) and adds a test for one of them.

For instance,

    Synonym = Crate
    Aggregate1 = Synonym and Target
    Aggregate2 = Aggregate1 and Background

currently breaks the parser.  Also,

    OBJECTS
    
    Background .
    Green
    
    Player P
    Blue
    
    LEGEND
    
    These = Background and Player
    Those = These
    
    SOUNDS
    
    COLLISIONLAYERS
    
    Background
    Player, Those
    
    RULES
    
    WINCONDITIONS
    
    LEVELS
    
    P.
    
actually compiles and runs, as the synonym `Those` is not resolved any further than `Those = These`.