### PR TITLE
Fix error in compiler with resolving multiple aggregate movements

### DIFF
--- a/js/compiler.js
+++ b/js/compiler.js
@@ -1183,7 +1183,7 @@ function concretizeMovingRule(state, rule,lineNumber) {
 							for(var moveTerm in cur_rule.movingReplacement) {
 								if (cur_rule.movingReplacement.hasOwnProperty(moveTerm)) {
 									var moveDat = cur_rule.movingReplacement[moveTerm];
-									newrule.movingReplacement[moveTerm] = [moveDat[0],moveDat[1],moveDat[3]];
+									newrule.movingReplacement[moveTerm] = [moveDat[0],moveDat[1],moveDat[2]];
 								}
 							}
 


### PR DESCRIPTION
Having multiple (different) aggregate movements to resolve would incorrectly produce compilation errors.
(E.g.: `[ horizontal Player ] [ vertical Crate ] -> [ horizontal Player ] [ horizontal Crate ]`)