### PR TITLE
Require section names to match the whole line

### DIFF
--- a/js/parser.js
+++ b/js/parser.js
@@ -162,7 +162,7 @@ var codeMirrorFn = function() {
     var reg_number = /[\d]+/;
     var reg_soundseed = /\d+\b/;
     var reg_spriterow = /[\.0-9]{5}\s*/;
-    var reg_sectionNames = /(objects|collisionlayers|legend|sounds|rules|winconditions|levels)\s*/;
+    var reg_sectionNames = /^\s*(objects|collisionlayers|legend|sounds|rules|winconditions|levels)\s*$/;
     var reg_equalsrow = /[\=]+/;
     var reg_notcommentstart = /[^\(]+/;
     var reg_csv_separators = /[ \,]*/;

--- a/js/parser.js
+++ b/js/parser.js
@@ -162,7 +162,7 @@ var codeMirrorFn = function() {
     var reg_number = /[\d]+/;
     var reg_soundseed = /\d+\b/;
     var reg_spriterow = /[\.0-9]{5}\s*/;
-    var reg_sectionNames = /(objects|collisionlayers|legend|sounds|rules|winconditions|levels)(?![a-zA-Z])\s*/;
+    var reg_sectionNames = /(objects|collisionlayers|legend|sounds|rules|winconditions|levels)(?![\w])\s*/;
     var reg_equalsrow = /[\=]+/;
     var reg_notcommentstart = /[^\(]+/;
     var reg_csv_separators = /[ \,]*/;

--- a/js/parser.js
+++ b/js/parser.js
@@ -162,7 +162,7 @@ var codeMirrorFn = function() {
     var reg_number = /[\d]+/;
     var reg_soundseed = /\d+\b/;
     var reg_spriterow = /[\.0-9]{5}\s*/;
-    var reg_sectionNames = /^\s*(objects|collisionlayers|legend|sounds|rules|winconditions|levels)\s*$/;
+    var reg_sectionNames = /(objects|collisionlayers|legend|sounds|rules|winconditions|levels)(?![a-zA-Z])\s*/;
     var reg_equalsrow = /[\=]+/;
     var reg_notcommentstart = /[^\(]+/;
     var reg_csv_separators = /[ \,]*/;


### PR DESCRIPTION
See related issue about section names parsing in a too greedy way: #409

This fix just changes the regex to require the section line to consist only of the section name with optional whitespace.