### PR TITLE
Share via OAuth-authenticated gists

### DIFF
--- a/access_token.py
+++ b/access_token.py
@@ -1,0 +1,70 @@
+#!/usr/bin/env python3
+
+"""Proxies a request for a GitHub access_token.
+
+This script handles the server-side part of Github authentication.
+PuzzleScript uses it to get an access token after a user gives
+PuzzleScript permission to write gists on their behalf.
+
+To use this script, register a Github OAuth application at
+https://github.com/settings/developers and update the OAUTH_CLIENT and
+OAUTH_SECRET values below to match. Add any allowed domains to
+ORIGIN_LIST (they need to use HTTPS).
+
+Install python-requests:
+    $ sudo apt-get install python3-pip
+    $ sudo pip install requests
+
+Set it up as a cgi script on your web server. The server needs to
+provide the HTTP_ORIGIN header.
+"""
+
+import cgi
+import json
+import os
+import requests
+import sys
+
+OAUTH_CLIENT = "xxxxxxxxxxxxxxxxxxxx"
+OAUTH_SECRET = "xxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxx"
+ORIGIN_LIST = [
+    "www.puzzlescript.net",
+    "www.increpare.com",
+    "increpare.github.io",
+    "sfiera.github.io",
+]
+
+LOGIN_URL = "https://github.com/login/oauth/access_token"
+LOGIN_HEADERS = {
+    "user-agent": "puzzlescript",
+    "accept": "application/json",
+}
+
+origin = os.environ.get("HTTP_ORIGIN", "")
+if not origin.startswith("https://") or (origin[8:] not in ORIGIN_LIST):
+    print("Content-type: text/plain")
+    print()
+    json.dump({"error": "invalid origin"}, sys.stdout)
+    sys.exit(0)
+
+form = cgi.FieldStorage()
+code = form.getfirst("code", "")
+state = form.getfirst("state", "")
+
+try:
+    data = requests.get(
+            LOGIN_URL,
+            headers=LOGIN_HEADERS,
+            data={
+                "client_id": OAUTH_CLIENT,
+                "client_secret": OAUTH_SECRET,
+                "code": code,
+                "state": state,
+            }).json()
+except Exception as e:
+    data = {"error": type(e).__name__}
+
+print("Content-type: application/json")
+print("Access-Control-Allow-Origin: " + origin)
+print()
+json.dump(data, sys.stdout)

--- a/auth.html
+++ b/auth.html
@@ -1,0 +1,73 @@
+<!doctype html>
+<html>
+<head>
+<meta charset="UTF-8">
+<title>PuzzleScript Login</title>
+
+</head>
+
+<body>
+	<pre id="pre"></pre>
+
+<script>
+
+(function() {
+
+// An external helper that can exchange a code for an access token.
+//
+// It fetches https://github.com/login/oauth/access_token, passing:
+//   * code and state, which the caller has to provide as query parameters.
+//   * client_id, same as OAUTH_CLIENT_ID above.
+//   * client_secret, which corresponds to client_id, but is secret on the server.
+//
+// It returns an access token as JSON, something like:
+//   {"access_token": "a440b61aa137bb25bb739b697ef5c96a76881107"}
+//
+// The server has CORS set up so that puzzlescript.net can access it.
+OAUTH_HELPER_URL = "https://twotaled.com/puzzleauth/access_token";
+
+var pre = document.getElementById("pre");
+
+var url = new URL(window.location);
+var code = url.searchParams.get("code");
+var state = url.searchParams.get("state");
+
+if (typeof code !== "string" || typeof state !== "string") {
+	pre.innerText = "Nothing to see here.";
+	return;
+}
+
+pre.innerText = "Just a moment…";
+
+var xhr = new XMLHttpRequest();
+xhr.open("GET", OAUTH_HELPER_URL + "?code=" + code + "&state=" + state);
+xhr.onreadystatechange = function() {
+	if (xhr.readyState !== 4) {
+		return;
+	}
+
+	if (xhr.status === 403) {
+		pre.innerText = result.message;
+		return;
+	} else if ((xhr.status !== 200) && (xhr.status !== 201)) {
+		pre.innerText = "HTTP Error " + xhr.status + " - " + xhr.statusText;
+		return;
+	}
+
+	var result = JSON.parse(xhr.responseText);
+	console.log(result);
+	if (typeof result.error === "string") {
+		pre.innerText = "Oops, got an error: " + JSON.stringify(result, null, 4);
+		return;
+	}
+
+	window.localStorage.setItem("oauth_access_token", result.access_token);
+	pre.innerText = "OK! You’re all set up. You can close this window and share your game :)";
+}
+xhr.send();
+
+})();
+
+</script>
+</body>
+</html>

--- a/js/toolbar.js
+++ b/js/toolbar.js
@@ -1,3 +1,9 @@
+// The client ID of a GitHub OAuth app registered at https://github.com/settings/developers.
+// The “callback URL” of that app points to https://www.puzzlescript.net/auth.html.
+// If you’re running from another host name, sharing might not work.
+OAUTH_CLIENT_ID = "52a4e0d89c82c5c29417";
+
+
 function runClick() {
 	clearConsole();
 	compile(["restart"]);
@@ -146,6 +152,27 @@ function levelEditorClick_Fn() {
 }
 
 function shareClick() {
+	var oauthAccessToken = window.localStorage.getItem("oauth_access_token");
+	if (typeof oauthAccessToken !== "string") {
+		// Generates 32 letters of random data, like "liVsr/e+luK9tC02fUob75zEKaL4VpQn".
+		var randomState = window.btoa(Array.prototype.map.call(
+				window.crypto.getRandomValues(new Uint8Array(24)),
+				function(x) { return String.fromCharCode(x); }).join(""));
+
+		var authUrl = "https://github.com/login/oauth/authorize"
+			+ "?client_id=" + OAUTH_CLIENT_ID
+			+ "&scope=gist"
+			+ "&state=" + randomState
+			+ "&allow_signup=true";
+		consolePrint(
+				"PuzzleScript needs permission to share games through GitHub:<br>" +
+				"<ul>" +
+				"<li><a target=\"_blank\" href=\"https://github.com/join\">Create a GitHub account</a></li>" +
+				"<li><a target=\"_blank\" href=\"" + authUrl + "\">Give PuzzleScript permission</a></li>" +
+				"</ul>");
+		return;
+	}
+
 	consolePrint("Sending code to github...",true)
 	var title = "Untitled PuzzleScript Script";
 	if (state.metadata.title!==undefined) {
@@ -169,7 +196,7 @@ function shareClick() {
 		}
 	};
 
-	var githubURL = 'https://api.github.com/gists';
+	var githubURL = 'https://api.github.com/gists?access_token=' + oauthAccessToken;
 	var githubHTTPClient = new XMLHttpRequest();
 	githubHTTPClient.open('POST', githubURL);
 	githubHTTPClient.onreadystatechange = function() {		


### PR DESCRIPTION
We’re getting down to the wire for #431, so I went ahead and tried to implement #306.

Check it out: https://sfiera.github.io/PuzzleScript/editor.html

It turns out to not be that much code. You probably shouldn’t merge this yet, though. The main questions are about the two constants, `OAUTH_CLIENT_ID` and `OAUTH_HELPER_URL`.

`OAUTH_CLIENT_ID` is easy: you can create your own application at https://github.com/settings/developers and I can change it to match.

`OAUTH_HELPER_URL` is trickier. I am willing to run the server, but it’s your call since puzzlescript.net is your website and sharing is an important part. I have other websites on my server that I do my best to keep online, but I can’t promise 100% uptime. In any case, whatever server it is ought to have a more permanent URL.
(if I do run it for PuzzleScript, I’m happy to do the same for flickgame and tinychoice)

There’s also missing stuff you might want in a final version:
* A sign-out button
* A nicer version of auth.html
* Better error handling (e.g. if the helper url is down, or the user revokes OAuth permission)

I figured I should check in with you before looking into any of those, though. For now, sign-out with `window.localStorage.removeItem("oauth_access_token")` in the console.