### PR TITLE
Unsaved changes prompt & autosave

### DIFF
--- a/css/toolbar.css
+++ b/css/toolbar.css
@@ -8,3 +8,14 @@
 	user-select: none;
 	cursor:default;
 }*/
+
+
+#autosaveCheckbox {
+	margin-top: 0;
+	vertical-align: middle;
+}
+
+#autosave input+label {
+	text-decoration: underline;
+	color: #e06f8b;
+}

--- a/editor.html
+++ b/editor.html
@@ -97,7 +97,7 @@ LEVELS
 
 <div id="uppertoolbar">
 	&nbsp;&nbsp;&nbsp;<a href="index.html"><h2>PuzzleScript</h2></a> - <a id="saveClickLink" href="javascript:void(0);">SAVE</a> - 
-
+	<span id="autosave"><input type="checkbox" id="autosaveCheckbox" autocomplete="off" /><label for="autosaveCheckbox">AUTOSAVE</label></span> - 
 	<form action="" style="display:inline;"><select id="loadDropDown" name="default" style="display:inline; width:100px"> -
 </select></form> - <form action="" style="display:inline;"> <select  id="exampleDropdown"  name="default" style="display:inline; width:150px">
 <option value="sokoban_basic">Load Example</option>

--- a/js/addlisteners_editor.js
+++ b/js/addlisteners_editor.js
@@ -26,6 +26,9 @@ levelEditorClickLink.addEventListener("click", levelEditorClick_Fn, false);
 var exportClickLink = document.getElementById("exportClickLink");
 exportClickLink.addEventListener("click", exportClick, false);
 
+var autosaveCheckbox = document.getElementById("autosaveCheckbox");
+autosaveCheckbox.addEventListener("change", autosaveToggle, false);
+
 var exampleDropdown = document.getElementById("exampleDropdown");
 exampleDropdown.addEventListener("change", dropdownChange, false);
 

--- a/js/editor.js
+++ b/js/editor.js
@@ -162,7 +162,19 @@ function tryLoadFile(fileName) {
 }
 
 function dropdownChange() {
+	if(!canExit()) {
+		this.selectedIndex = 0;
+		return;
+	}
+
 	tryLoadFile(this.value);
 	this.selectedIndex=0;
 }
 
+function canExit() {
+	if(!_editorDirty) {
+		return true;
+	}
+
+	return confirm("You have unsaved changes! Do you want to lose changes and proceed?")
+}

--- a/js/editor.js
+++ b/js/editor.js
@@ -1,6 +1,7 @@
 var code = document.getElementById('code');
 var _editorDirty = false;
 var _editorCleanState = "";
+var _autosaveMode = false;
 
 var fileToOpen=getParameterByName("demo");
 if (fileToOpen!==null&&fileToOpen.length>0) {
@@ -169,6 +170,67 @@ function dropdownChange() {
 
 	tryLoadFile(this.value);
 	this.selectedIndex=0;
+}
+
+function autosaveCheck() {
+	if(!_autosaveMode || !_editorDirty) {
+		return;
+	}
+
+	// autosave replaces existing autosave slot for given game name or creates new
+
+	var saveDat = getSaveData();
+	saveDat.title += " (Autosave)"
+
+	var curSaveArray = [];
+	if (localStorage['saves'] !== undefined) {
+		curSaveArray = JSON.parse(localStorage.saves);
+	}
+
+	var index = -1;
+	for(var i = 0; i < curSaveArray.length; i++) {
+		if(curSaveArray[i].title === saveDat.title) {
+			index = i;
+			break;
+		}
+	}
+
+	if(index == -1) {
+		curSaveArray.push(saveDat);
+	} else {
+		curSaveArray[index] = saveDat;
+	}
+
+	save(curSaveArray);
+}
+
+setInterval(autosaveCheck, 5000);
+
+function getSaveData() {
+	var title = "Untitled";
+	if (state.metadata.title !== undefined) {
+		title = state.metadata.title;
+	}
+
+	var text = editor.getValue();
+	
+	return {
+		title: title,
+		text: text,
+		date: new Date()
+	}
+}
+
+function save(saveArray) {
+	var savesDatStr = JSON.stringify(saveArray);
+	localStorage['saves'] = savesDatStr;
+
+	repopulateSaveDropdown(saveArray);
+
+	var loadDropdown = document.getElementById('loadDropDown');
+	loadDropdown.selectedIndex = 0;
+
+	setEditorClean();
 }
 
 function canExit() {

--- a/js/editor.js
+++ b/js/editor.js
@@ -195,11 +195,11 @@ function autosaveCheck() {
 		}
 	}
 
-	if(index == -1) {
-		curSaveArray.push(saveDat);
-	} else {
-		curSaveArray[index] = saveDat;
+	if(index != -1) {
+		curSaveArray.splice(index, 1);
 	}
+	
+	curSaveArray.push(saveDat);
 
 	save(curSaveArray);
 }
@@ -238,5 +238,5 @@ function canExit() {
 		return true;
 	}
 
-	return confirm("You have unsaved changes! Do you want to lose changes and proceed?")
+	return confirm("You have unsaved changes! Do you want to proceed and lose changes?")
 }

--- a/js/toolbar.js
+++ b/js/toolbar.js
@@ -75,6 +75,11 @@ function saveClick() {
 
 
 function loadDropDownChange() {
+	if(!canExit()) {
+		this.selectedIndex = 0;
+		return;
+	}
+
 	var saveString = localStorage['saves'];
 	if (saveString===undefined) {
 			consolePrint("Eek, trying to load a file, but there's no local storage found. Eek!",true);

--- a/js/toolbar.js
+++ b/js/toolbar.js
@@ -37,16 +37,7 @@ function dateToReadable(title,time) {
 }
 
 function saveClick() {
-	var title = "Untitled";
-	if (state.metadata.title!==undefined) {
-		title=state.metadata.title;
-	}
-	var text=editor.getValue();
-	var saveDat = {
-		title:title,
-		text:text,
-		date: new Date()
-	}
+	var saveDat = getSaveData();
 
 	var curSaveArray = [];
 	if (localStorage['saves']===undefined) {
@@ -59,20 +50,15 @@ function saveClick() {
 		curSaveArray.splice(0,1);
 	}
 	curSaveArray.push(saveDat);
-	var savesDatStr = JSON.stringify(curSaveArray);
-	localStorage['saves']=savesDatStr;
-
-	repopulateSaveDropdown(curSaveArray);
-
-	var loadDropdown = document.getElementById('loadDropDown');
-	loadDropdown.selectedIndex=0;
-
-	setEditorClean();
+	
+	save(curSaveArray);;
 
 	consolePrint("saved file to local storage",true);
 }
 
-
+function autosaveToggle() {
+	_autosaveMode = this.checked;
+}
 
 function loadDropDownChange() {
 	if(!canExit()) {


### PR DESCRIPTION
1. Unsaved changes prompt
Editor keeps track of dirty flag and prevents user from accidentally exiting page without saving. However, loading previously saved games or examples would drop any changes. Added prompt that fixes that.
![image](https://user-images.githubusercontent.com/7289043/41128313-00fb0790-6aae-11e8-9f8b-2c64737a2b7f.png)

2. Autosave
When autosave checkbox is selected, every 5s editor checks if it's in dirty state and saves. Autosaves are saved to slot with " (Autosave)" appended to the name. If such save slot already exists, it's replaced.