### PR TITLE
Fix scrolling on iOS devices [Fixes #446]

### DIFF
--- a/js/mobile.js
+++ b/js/mobile.js
@@ -115,6 +115,7 @@ Mobile.debugDot = function (event) {
 
     proto.bootstrap = function () {
         this.showTab();
+        this.disableScrolling();
         if (!this.isAudioSupported()) {
             this.disableAudio();
         }
@@ -653,6 +654,22 @@ Mobile.debugDot = function (event) {
 
         this.menuElem.setAttribute('style', opacityString);
     };
+
+    proto.disableScrolling = function() {
+        var style = {
+            height: "100%",
+            overflow: "hidden",
+            position: "fixed",
+            width: "100%"
+        }
+        
+        var styleString = "";
+        for (var key in style) {
+            styleString += key + ": " + style[key] + "; ";
+        }
+
+        document.body.setAttribute('style', styleString)
+    }
 
     /** Audio Methods **/
 


### PR DESCRIPTION
Here ya go!

A few concerns:

* I tested this by making my changes directly to mobile.js and loading a locally-served copy of `play.html`. Exported games didn't have my changes in them. I haven't taken the time to fully process all of your compile/deploy scripts in the repo, but is it safe to assume that by the time you deploy this, those changes would percolate out to everywhere they need to be?

* It's worth testing these on Android. I'm not sure if Android is currently exhibiting similar issues as iOS, but it would be good to know (a) if this fixes any existing Android issues and (b) if this causes any new Android issues.

* It looks like the "mobile" check is really a "touch device" check. I don't know what this CSS will do on, say, a Surface Pro with a large screen that's also a touch screen. It might be safer to additionally wrap this in a media query that checks for a maximum screen size, but it wasn't immediately clear to me where that CSS should live (since play.html doesn't import any external CSS, I wasn't sure if moving this fix to CSS and having JS just add a class would mean putting it in multiple places)