### PR TITLE
Fix for #419 chrome audio issue (also #438)

### DIFF
--- a/js/sfxr.js
+++ b/js/sfxr.js
@@ -24,6 +24,10 @@ function checkAudioContextExists(){
         AUDIO_CONTEXT = new webkitAudioContext();
       }
     }
+	
+	if(AUDIO_CONTEXT != null && AUDIO_CONTEXT.state == "suspended") {
+		AUDIO_CONTEXT.resume().then(function() { window.console.log("Resumed AudioContext") });
+	}
   }
   catch (ex){
     window.console.log(ex)

--- a/js/sfxr.js
+++ b/js/sfxr.js
@@ -24,10 +24,10 @@ function checkAudioContextExists(){
         AUDIO_CONTEXT = new webkitAudioContext();
       }
     }
-	
-	if(AUDIO_CONTEXT != null && AUDIO_CONTEXT.state == "suspended") {
-		AUDIO_CONTEXT.resume().then(function() { window.console.log("Resumed AudioContext") });
-	}
+
+    if(AUDIO_CONTEXT != null && AUDIO_CONTEXT.state == "suspended") {
+	    AUDIO_CONTEXT.resume().then(function() { window.console.log("Resumed AudioContext") });
+    }
   }
   catch (ex){
     window.console.log(ex)

--- a/js/sfxr.js
+++ b/js/sfxr.js
@@ -26,7 +26,7 @@ function checkAudioContextExists(){
     }
 
     if(AUDIO_CONTEXT != null && AUDIO_CONTEXT.state == "suspended") {
-	    AUDIO_CONTEXT.resume().then(function() { window.console.log("Resumed AudioContext") });
+        AUDIO_CONTEXT.resume().then(function() { window.console.log("Resumed AudioContext") });
     }
   }
   catch (ex){


### PR DESCRIPTION
Add resume call to checkAudioContextExists so that the context will be resumed when attempting to play a sound when the context is in suspended mode.

This happens if the web page tries to initialize the context before a user has interacted with the page (or at least [will happen soon?](https://bugs.chromium.org/p/chromium/issues/detail?id=840866#c103)).