### PR TITLE
Documentation for permanent URLs is out of date

### DIFF
--- a/Documentation/permanent_urls.html
+++ b/Documentation/permanent_urls.html
@@ -60,12 +60,11 @@
     <p>
     If you want to share a link to a puzzle you've made, but still be able to update it (in case there are bugs you want to fix, or new levels you want to add), here's how you do that:
 <ul>
-<li>Click Share in the PuzzleScript editor as you normally would.</li>
-<li>Copy the ID at the end of the shareable URL that PuzzleScript just generated for you: <a href="https://www.puzzlescript.net/play.html?p=6878337">https://www.puzzlescript.net/play.html?p=<span style="color:magenta;font-weight:bold;">6878337</span></a>, and paste it at the end of this URL: <a href="https://gist.github.com/anonymous/6878337">https://gist.github.com/anonymous/<span style="color:magenta;font-weight:bold;">6878337</span></a>.</li>
-<li>If you're signed into <a href="https://github.com">GitHub</a>, you should see a button labelled Fork. Press that. (If you don't have a <a href="https://github.com">GitHub</a> account, you'll need to create one for the following to work).</li>
-<li>Now you have your own updatable PuzzleScript file! Take the ID at the end of the URL of your fork (it will be different to the one you pasted above) and perform Step 2 in reverse to find out your shareable and updatable game URL.</li>
+<li>Click Share in the PuzzleScript editor.</li>
+<li>Copy the ID at the end of the shareable URL that PuzzleScript just generated for you: <a href="https://www.puzzlescript.net/play.html?p=6878337">https://www.puzzlescript.net/play.html?p=<span style="color:magenta;font-weight:bold;">6878337</span></a>, and paste it at the end of this URL: <a href="https://gist.github.com/6878337">https://gist.github.com/<span style="color:magenta;font-weight:bold;">6878337</span></a>.</li>
+<li>If you're signed into <a href="https://github.com">GitHub</a>, you should see a button labelled Edit. Press that and copy your updated game over.</li>
+<li>The game at <a href="https://gist.github.com/6878337">https://gist.github.com/<span style="color:magenta;font-weight:bold;">6878337</span></a> is now up to date.</li>
 </ul>
-Now anytime you want to update it, just go back to the fork you made, make some changes, and the same game URL should be updated too!
     </div><!-- /.container -->
 
 


### PR DESCRIPTION
Hasn't been updated since the change that disallowed anonymous gists.