### PR TITLE
Use OAuth token if available when loading gists

### DIFF
--- a/src/js/editor.js
+++ b/src/js/editor.js
@@ -121,6 +121,10 @@ function tryLoadGist(id) {
 
 	consolePrint("Contacting GitHub",true);
 	var githubHTTPClient = new XMLHttpRequest();
+	var oauthAccessToken = window.localStorage.getItem("oauth_access_token");
+	if (typeof oauthAccessToken === "string") {
+		githubHTTPClient.setRequestHeader("Authorization","token "+oauthAccessToken);
+	}
 	githubHTTPClient.open('GET', githubURL);
 	githubHTTPClient.onreadystatechange = function() {
 	


### PR DESCRIPTION
Every time I try to load a gist in the Puzzlescript editor, I get this error: "API rate limit exceeded for [my IP address]. (But here's the good news: Authenticated requests get a higher rate limit. Check out the documentation for more details.)"
I'm pretty sure this is because I have a bunch of other scripts that use the Github API so I very quickly exceed the rate-limit for unauthenticated requests.