### PR TITLE
Don't clear message text on restart/cancel

### DIFF
--- a/src/js/engine.js
+++ b/src/js/engine.js
@@ -2388,7 +2388,6 @@ function processInput(dir,dontDoWin,dontModify) {
 			}
 			processOutputCommands(level.commandQueue);
     		backups.push(bak);
-			messagetext = "";
     		DoUndo(true,false);
     		tryPlayCancelSound();
     		return false;
@@ -2402,7 +2401,6 @@ function processInput(dir,dontDoWin,dontModify) {
 			}
 			processOutputCommands(level.commandQueue);
     		backups.push(bak);
-			messagetext = "";
 	    	DoRestart(true);
     		return true;
 		} 


### PR DESCRIPTION
Red pill solution to fix increpare/PuzzleScript#627 (alternative blue pill is PR #629). This solution keeps the recent breaking change of `restart`/`cancel` no longer bypassing `message`s. See the issue for more detail.

As of 03f6f77, `restart`/`cancel` no longer bypass `message`s, so clearing the message text causes an exception to be thrown. This commit no longer clears the message text.

This is one of two options being presented to fix this bug. The alternative is to revert back to the behaviour of `restart`/`cancel` bypassing `message`s - PR #629.