### PR TITLE
Bypass messages when doing restart/cancel

### DIFF
--- a/src/js/engine.js
+++ b/src/js/engine.js
@@ -2061,16 +2061,11 @@ function showTempMessage() {
 	canvasResize();
 }
 
-function processOutputCommands(commands) {
+function processSfxCommands(commands) {
 	for (var i=0;i<commands.length;i++) {
 		var command = commands[i];
 		if (command.charAt(1)==='f')  {//identifies sfxN
 			tryPlaySimpleSound(command);
-		}
-		if (unitTesting===false) {
-			if (command==='message') {
-				showTempMessage();
-			}
 		}
 	}
 }
@@ -2386,7 +2381,7 @@ function processInput(dir,dontDoWin,dontModify) {
 	    		var r = level.commandQueueSourceRules[level.commandQueue.indexOf('cancel')];
 	    		consolePrintFromRule('CANCEL command executed, cancelling turn.',r,true);
 			}
-			processOutputCommands(level.commandQueue);
+			processSfxCommands(level.commandQueue);
     		backups.push(bak);
 			messagetext = "";
     		DoUndo(true,false);
@@ -2400,7 +2395,7 @@ function processInput(dir,dontDoWin,dontModify) {
 	    		consolePrintFromRule('RESTART command executed, reverting to restart state.',r);
 	    		consoleCacheDump();
 			}
-			processOutputCommands(level.commandQueue);
+			processSfxCommands(level.commandQueue);
     		backups.push(bak);
 			messagetext = "";
 	    	DoRestart(true);
@@ -2461,7 +2456,18 @@ function processInput(dir,dontDoWin,dontModify) {
         	}
         }
 
-	    processOutputCommands(level.commandQueue);
+		processSfxCommands(level.commandQueue);
+
+		for (var i=0;i<level.commandQueue.length;i++) {
+			var command = level.commandQueue[i];
+			if (unitTesting===false) {
+				if (command==='message') {
+					showTempMessage();
+				}
+			} else {
+				messagetext = "";
+			}
+		}
 
 	    if (textMode===false) {
 	    	if (verbose_logging) { 


### PR DESCRIPTION
Blue pill solution to fix increpare/PuzzleScript#627 (alternative red pill is PR #628). This solution reverts the recent breaking change of `restart`/`cancel` no longer bypassing `message`s. See the issue for more detail.

03f6f77 introduced a couple of changes, one of which was that `restart`/`cancel` would no longer bypass `message`s. This may have broken older games and introduced a new bug where it would skip to the next level instead of `restart`ing or `cancel`ing. This commit reverts that change (while keeping the change that allows `restart` and `cancel` to have sound effects).

This is one of two options being presented to fix this bug. The alternative is to continue bypassing messages with `restart`/`cancel` and instead don't clear the message text. - PR #628.