### PR TITLE
Add title, author, homepage to gallery database

### DIFF
--- a/src/games_dat.js
+++ b/src/games_dat.js
@@ -1,466 +1,770 @@
 var games_gallery = [
   {
     "url": "https://www.puzzlescript.net/play.html?p=6841165",
-    "thumb": "6841165.gif"
+    "thumb": "6841165.gif",
+    "title": "2D Whale World",
+    "author": "increpare",
+    "homepage": "www.increpare.com"
   },
   {
     "url": "https://www.puzzlescript.net/play.html?p=6841219",
-    "thumb": "6841219.gif"
+    "thumb": "6841219.gif",
+    "title": "Microban",
+    "author": "David Skinner",
+    "homepage": "www.sneezingtiger.com/sokoban/levels/microbanText.html"
   },
   {
     "url": "https://www.puzzlescript.net/play.html?p=6841210",
-    "thumb": "6841210.gif"
+    "thumb": "6841210.gif",
+    "title": "Lime Rick",
+    "author": "Tommi Tuovinen",
+    "homepage": "https://www.kissmaj7.com/"
   },
   {
     "url": "https://www.puzzlescript.net/play.html?p=6845074",
-    "thumb": "6845074.gif"
+    "thumb": "6845074.gif",
+    "title": "Multi-word Dictionary Game",
+    "author": "Sarah Northway",
+    "homepage": "www.sarahnorthway.com"
   },
   {
     "url": "https://www.puzzlescript.net/play.html?p=6878337",
-    "thumb": "6878337.gif"
+    "thumb": "6878337.gif",
+    "title": "Midas",
+    "author": "wanderlands",
+    "homepage": "www.wanderlands.org"
   },
   {
     "url": "https://www.puzzlescript.net/play.html?p=6847423",
-    "thumb": "6847423.gif"
+    "thumb": "6847423.gif",
+    "title": "It Dies In The Light",
+    "author": "Christopher Wells",
+    "homepage": "www.tophwells.com"
   },
   {
     "url": "https://www.puzzlescript.net/play.html?p=6846450",
-    "thumb": "6846450.gif"
+    "thumb": "6846450.gif",
+    "title": "Love and Pieces",
+    "author": "lexaloffle",
+    "homepage": "www.lexaloffle.com"
   },
   {
     "url": "https://www.puzzlescript.net/play.html?p=6860122",
-    "thumb": "6860122.gif"
+    "thumb": "6860122.gif",
+    "title": "Heroes of Sokoban",
+    "author": "Jonah Ostroff"
   },
   {
     "url": "https://www.puzzlescript.net/play.html?p=6851495",
-    "thumb": "6851495.gif"
+    "thumb": "6851495.gif",
+    "title": "MC Escher's Equestrian Armageddon",
+    "author": "Anna Clarke"
   },
   {
     "url": "https://www.puzzlescript.net/play.html?p=6877049",
-    "thumb": "6877049.gif"
+    "thumb": "6877049.gif",
+    "title": "IceCrates",
+    "author": "Tyler Glaiel",
+    "homepage": "https://twitter.com/tylerglaiel"
   },
   {
     "url": "https://www.puzzlescript.net/play.html?p=6866423",
-    "thumb": "6866423.gif"
+    "thumb": "6866423.gif",
+    "title": "Dungeon Janitor",
+    "author": "Farbs",
+    "homepage": "www.farbs.org"
   },
   {
     "url": "https://www.puzzlescript.net/play.html?p=11358856",
-    "thumb": "11358856.gif"
+    "thumb": "11358856.gif",
+    "title": "Collapse",
+    "author": "Terry Cavanagh",
+    "homepage": "www.distractionware.com"
   },
   {
     "url": "https://www.puzzlescript.net/play.html?p=6877929",
-    "thumb": "6877929.gif"
+    "thumb": "6877929.gif",
+    "title": "Explod",
+    "author": "CHz",
+    "homepage": "quiteajolt.com"
   },
   {
     "url": "https://www.puzzlescript.net/play.html?p=fcf4b43ee6c679ef9389",
-    "thumb": "fcf4b43ee6c679ef9389.gif"
+    "thumb": "fcf4b43ee6c679ef9389.gif",
+    "title": "Cake Monsters",
+    "author": "Matt Rix",
+    "homepage": "www.magicule.com"
   },
   {
     "url": "https://www.puzzlescript.net/play.html?p=6878681",
-    "thumb": "6878681.gif"
+    "thumb": "6878681.gif",
+    "title": "Kettle",
+    "author": "stephen lavelle",
+    "homepage": "www.increpare.com"
   },
   {
     "url": "https://www.puzzlescript.net/play.html?p=6879013",
-    "thumb": "6879013.gif"
+    "thumb": "6879013.gif",
+    "title": "Ebony & Ivory",
+    "author": "Guilherme T\u00f6ws",
+    "homepage": "zarat.us"
   },
   {
     "url": "https://www.puzzlescript.net/play.html?p=9675709",
-    "thumb": "9675709.gif"
+    "thumb": "9675709.gif",
+    "title": "Bouncers",
+    "author": "Tyler Glaiel",
+    "homepage": "https://twitter.com/tylerglaiel"
   },
   {
     "url": "https://www.puzzlescript.net/play.html?p=6880313",
-    "thumb": "6880313.gif"
+    "thumb": "6880313.gif",
+    "title": "The Legend of Zokoban",
+    "author": "Joshua Minor",
+    "homepage": "pixelverse.org"
   },
   {
     "url": "https://www.puzzlescript.net/play.html?p=9a76ddbe9e8f687c2a75",
-    "thumb": "9a76ddbe9e8f687c2a75.gif"
+    "thumb": "9a76ddbe9e8f687c2a75.gif",
+    "title": "Dang I'm Huge",
+    "author": "Guilherme Tows",
+    "homepage": "zarat.us"
   },
   {
     "url": "https://www.puzzlescript.net/play.html?p=6893137",
-    "thumb": "6893137.gif"
+    "thumb": "6893137.gif",
+    "title": "tiny treasure hunt 1.0",
+    "author": "Weeble",
+    "homepage": "www.twitter.com/weeble"
   },
   {
     "url": "https://www.puzzlescript.net/play.html?p=6910207",
-    "thumb": "6910207.gif"
+    "thumb": "6910207.gif",
+    "title": "Heroes of Sokoban II: Monsters",
+    "author": "Jonah Ostroff"
   },
   {
     "url": "https://www.puzzlescript.net/play.html?p=6906326",
-    "thumb": "6906326.gif"
+    "thumb": "6906326.gif",
+    "title": "Sok7",
+    "author": "Kevin Cancienne",
+    "homepage": "https://twitter.com/potatojin"
   },
   {
     "url": "https://www.puzzlescript.net/play.html?p=6902186",
-    "thumb": "6902186.gif"
+    "thumb": "6902186.gif",
+    "title": "Take Heart Lass",
+    "author": "Kevin Zuhn",
+    "homepage": "www.kevinzuhn.com"
   },
   {
     "url": "https://www.puzzlescript.net/play.html?p=6872613",
-    "thumb": "6872613.gif"
+    "thumb": "6872613.gif",
+    "title": "Ponies Jumping Synchronously",
+    "author": "vytah"
   },
   {
     "url": "https://www.puzzlescript.net/play.html?p=9675998",
-    "thumb": "9675998.gif"
+    "thumb": "9675998.gif",
+    "title": "Closure Demake",
+    "author": "Tyler Glaiel",
+    "homepage": "www.closuregame.com"
   },
   {
     "url": "https://www.puzzlescript.net/play.html?p=6976592",
-    "thumb": "6976592.gif"
+    "thumb": "6976592.gif",
+    "title": "Memories Of Castlemouse",
+    "author": "Wayne Myers",
+    "homepage": "www.conniptions.org"
   },
   {
     "url": "https://www.puzzlescript.net/play.html?p=6994394",
-    "thumb": "6994394.gif"
+    "thumb": "6994394.gif",
+    "title": "Atlas Shrank",
+    "author": "James Noeckel"
   },
   {
     "url": "https://www.puzzlescript.net/play.html?p=6990366",
-    "thumb": "6990366.gif"
+    "thumb": "6990366.gif",
+    "title": "Colour Chained",
+    "author": "Dennis Au"
   },
   {
     "url": "https://www.sokobond.com/puzzlescript/",
-    "thumb": "sokobond.gif"
+    "thumb": "sokobond.gif",
+    "title": "Sokobond: The Demake",
+    "author": "Jonah Ostroff",
+    "homepage": "https://www.sokobond.com/"
   },
   {
     "url": "https://www.puzzlescript.net/play.html?p=7047165",
-    "thumb": "7047165.gif"
+    "thumb": "7047165.gif",
+    "title": "Tunnel Rat",
+    "author": "James Noeckel"
   },
   {
     "url": "https://www.puzzlescript.net/play.html?p=9121824",
-    "thumb": "9121824.gif"
+    "thumb": "9121824.gif",
+    "title": "cute train",
+    "author": "Mark Wonnacott",
+    "homepage": "https://twitter.com/ragzouken"
   },
   {
     "url": "https://www.puzzlescript.net/play.html?p=7057244",
-    "thumb": "7057244.gif"
+    "thumb": "7057244.gif",
+    "title": "Manic Ammo",
+    "author": "David Eastman"
   },
   {
     "url": "https://www.puzzlescript.net/play.html?p=7072276",
-    "thumb": "7072276.gif"
+    "thumb": "7072276.gif",
+    "title": "Heroes of Sokoban III: The Bard and The Druid",
+    "author": "Jonah Ostroff"
   },
   {
     "url": "https://www.puzzlescript.net/play.html?p=7114130",
-    "thumb": "7114130.gif"
+    "thumb": "7114130.gif",
+    "title": "Cratopia",
+    "author": "CHz [v1]",
+    "homepage": "quiteajolt.com"
   },
   {
     "url": "https://www.puzzlescript.net/play.html?p=7324598",
-    "thumb": "7324598.gif"
+    "thumb": "7324598.gif",
+    "title": "Flying Kick",
+    "author": "Aaron Steed",
+    "homepage": "www.robotacid.com"
   },
   {
     "url": "https://www.puzzlescript.net/play.html?p=c784daec18555b9d48f3",
-    "thumb": "c784daec18555b9d48f3.gif"
+    "thumb": "c784daec18555b9d48f3.gif",
+    "title": "Drop Swap",
+    "author": "Aaron Steed",
+    "homepage": "www.robotacid.com"
   },
   {
     "url": "https://candle.itch.io/chaos-wizard",
-    "thumb": "chaos-wizard.gif"
+    "thumb": "chaos-wizard.gif",
+    "title": "chaos wizard",
+    "author": "mark wonnacott",
+    "homepage": "https://twitter.com/ragzouken"
   },
   {
     "url": "https://www.puzzlescript.net/play.html?p=8931824",
-    "thumb": "8931824.gif"
+    "thumb": "8931824.gif",
+    "title": "Slidings",
+    "author": "Alain Brobecker",
+    "homepage": "abrobecker.free.fr"
   },
   {
     "url": "https://benjamindav.is/threes/",
-    "thumb": "threes.gif"
+    "thumb": "threes.gif",
+    "title": "Threes: The Demake",
+    "author": "Benjamin Davis",
+    "homepage": "https://asherv.com/threes/"
   },
   {
     "url": "https://www.puzzlescript.net/play.html?p=9582263",
-    "thumb": "9582263.gif"
+    "thumb": "9582263.gif",
+    "title": "Gobble Rush!",
+    "author": "Mark Richardson"
   },
   {
     "url": "https://www.puzzlescript.net/play.html?p=8632255",
-    "thumb": "8632255.gif"
+    "thumb": "8632255.gif",
+    "title": "Smother",
+    "author": "Team Borse"
   },
   {
     "url": "https://www.puzzlescript.net/play.html?p=8565753",
-    "thumb": "8565753.gif"
+    "thumb": "8565753.gif",
+    "title": "The Saga of the Candy Scroll",
+    "author": "Jim Palmeri"
   },
   {
     "url": "https://www.puzzlescript.net/play.html?p=9440559",
-    "thumb": "9440559.gif"
+    "thumb": "9440559.gif",
+    "title": "Pants, Shirt, Cap",
+    "author": "Jaewoong Hwang",
+    "homepage": "www.jaewoong.info"
   },
   {
     "url": "https://www.draknek.org/games/puzzlescript/candy.php",
-    "thumb": "candy.gif"
+    "thumb": "candy.gif",
+    "title": "Sticky Candy Puzzle Saga",
+    "author": "Alan Hazelden",
+    "homepage": "https://www.draknek.org"
   },
   {
     "url": "https://www.puzzlescript.net/play.html?p=7718522",
-    "thumb": "7718522.gif"
+    "thumb": "7718522.gif",
+    "title": "MazezaM",
+    "author": "Malcolm Tyrrell",
+    "homepage": "https://sites.google.com/site/malcolmsprojects/"
   },
   {
     "url": "https://www.puzzlescript.net/play.html?p=6888061",
-    "thumb": "6888061.gif"
+    "thumb": "6888061.gif",
+    "title": "Modality",
+    "author": "Sean Barrett",
+    "homepage": "www.silverspaceship.com"
   },
   {
     "url": "https://www.puzzlescript.net/play.html?p=9867759",
-    "thumb": "9867759.gif"
+    "thumb": "9867759.gif",
+    "title": "PUSH",
+    "author": "lonebot - demake by rmmh",
+    "homepage": "https://lonebot.itch.io/1push"
   },
   {
     "url": "https://www.draknek.org/games/puzzlescript/pulleys.php",
-    "thumb": "pulleys.gif"
+    "thumb": "pulleys.gif",
+    "title": "You're Pulleying My Leg",
+    "author": "Alan Hazelden",
+    "homepage": "https://www.draknek.org"
   },
   {
     "url": "https://www.puzzlescript.net/play.html?p=11359118",
-    "thumb": "11359118.gif"
+    "thumb": "11359118.gif",
+    "title": "Beam Islands",
+    "author": "mjau",
+    "homepage": "https://twitter.com/kamjau"
   },
   {
     "url": "https://www.puzzlescript.net/play.html?p=eb0f9102f85b5ea536b1",
-    "thumb": "eb0f9102f85b5ea536b1.gif"
+    "thumb": "eb0f9102f85b5ea536b1.gif",
+    "title": "Singleton Traffic",
+    "author": "Toph Wells",
+    "homepage": "www.tophwells.com"
   },
   {
     "url": "https://www.puzzlescript.net/play.html?p=cffeb1b80f76458b742a",
-    "thumb": "cffeb1b80f76458b742a.gif"
+    "thumb": "cffeb1b80f76458b742a.gif",
+    "title": "Aaaah! I'm Being Attacked by a Giant Tentacle!",
+    "author": "Ricky Liu"
   },
   {
     "url": "https://www.puzzlescript.net/play.html?p=6ec59e0b3f1f306acdc1",
-    "thumb": "6ec59e0b3f1f306acdc1.gif"
+    "thumb": "6ec59e0b3f1f306acdc1.gif",
+    "title": "Pornography for Beginners",
+    "author": "Holly",
+    "homepage": "hollygramazio.net"
   },
   {
     "url": "https://www.puzzlescript.net/play.html?p=0590a6662f9e8e6afe4a",
-    "thumb": "0590a6662f9e8e6afe4a.gif"
+    "thumb": "0590a6662f9e8e6afe4a.gif",
+    "title": "SwapBot",
+    "author": "John M. Williams",
+    "homepage": "gate.itch.io"
   },
   {
     "url": "https://www.puzzlescript.net/play.html?p=6a6c07f71d7039e4155e",
-    "thumb": "6a6c07f71d7039e4155e.gif"
+    "thumb": "6a6c07f71d7039e4155e.gif",
+    "title": "Spacekoban",
+    "author": "Connorses [Loneship Games]"
   },
   {
     "url": "https://www.ben-reilly.com/weakly-games/007-dinnertime/",
-    "thumb": "dinnertime.gif"
+    "thumb": "dinnertime.gif",
+    "title": "Dinnertime!",
+    "author": "Ben Reilly",
+    "homepage": "ben-reilly.com"
   },
   {
     "url": "https://www.puzzlescript.net/play.html?p=09d9778d0e69116c5406",
-    "thumb": "09d9778d0e69116c5406.gif"
+    "thumb": "09d9778d0e69116c5406.gif",
+    "title": "pretender to the crown",
+    "author": "colin thil",
+    "homepage": "https://pretendertothecrown.wordpress.com/"
   },
   {
     "url": "https://www.puzzlescript.net/play.html?p=ac003a3b7e159dd54eb8",
-    "thumb": "ac003a3b7e159dd54eb8.gif"
+    "thumb": "ac003a3b7e159dd54eb8.gif",
+    "title": "Boxes & Balloons",
+    "author": "Ben Reilly",
+    "homepage": "ben-reilly.com"
   },
   {
     "url": "https://www.puzzlescript.net/play.html?p=a8f4e5aed01de7c9ef50",
-    "thumb": "a8f4e5aed01de7c9ef50.gif"
+    "thumb": "a8f4e5aed01de7c9ef50.gif",
+    "title": "Pushcat Jr",
+    "author": "Zut!",
+    "homepage": "zutgames.com/pushcat"
   },
   {
     "url": "https://www.puzzlescript.net/play.html?p=d210a5248fa713153950",
-    "thumb": "d210a5248fa713153950.gif"
+    "thumb": "d210a5248fa713153950.gif",
+    "title": "Sokoboros",
+    "author": "Trevor Newton",
+    "homepage": "https://twitter.com/trevnewt"
   },
   {
     "url": "https://www.puzzlescript.net/play.html?p=d688de5e0e1e978f63fd",
-    "thumb": "d688de5e0e1e978f63fd.gif"
+    "thumb": "d688de5e0e1e978f63fd.gif",
+    "title": "Marble Shoot",
+    "author": "Stuart Burfield",
+    "homepage": "www.thepixelshelf.com"
   },
   {
     "url": "https://www.draknek.org/games/puzzlescript/cyber-lasso.php",
-    "thumb": "lasso.gif"
+    "thumb": "lasso.gif",
+    "title": "Cyber-Lasso",
+    "author": "Alan Hazelden",
+    "homepage": "https://www.draknek.org"
   },
   {
     "url": "https://www.draknek.org/games/puzzlescript/train.php",
-    "thumb": "train.gif"
+    "thumb": "train.gif",
+    "title": "Train Braining",
+    "author": "Alan Hazelden",
+    "homepage": "https://www.draknek.org"
   },
   {
     "url": "https://www.puzzlescript.net/play.html?p=e8ce49f2b9834e80516d",
-    "thumb": "e8ce49f2b9834e80516d.gif"
+    "thumb": "e8ce49f2b9834e80516d.gif",
+    "title": "Enqueue",
+    "author": "Allen Webster",
+    "homepage": "www.pushthegame.com"
   },
   {
     "url": "https://w.itch.io/aunt-floras-mansion",
-    "thumb": "mansion.gif"
+    "thumb": "mansion.gif",
+    "title": "Aunt Flora's Mansion",
+    "author": "anna anthropy",
+    "homepage": "https://w.itch.io/"
   },
   {
     "url": "https://www.puzzlescript.net/play.html?p=6faf74de7d562674e71a",
-    "thumb": "6faf74de7d562674e71a.gif"
+    "thumb": "6faf74de7d562674e71a.gif",
+    "title": "Tidy the Cafe!",
+    "author": "Sally Bridgwater",
+    "homepage": "https://sallyanne.itch.io"
   },
   {
     "url": "https://www.puzzlescript.net/play.html?p=2c9edcf6ba4a4d8720a7",
-    "thumb": "2c9edcf6ba4a4d8720a7.gif"
+    "thumb": "2c9edcf6ba4a4d8720a7.gif",
+    "title": "Flower Dance",
+    "author": "quat"
   },
   {
     "url": "https://www.puzzlescript.net/play.html?p=21e3784aaa7675dc4b08",
-    "thumb": "21e3784aaa7675dc4b08.gif"
+    "thumb": "21e3784aaa7675dc4b08.gif",
+    "title": "Stairways",
+    "author": "Franklin P. Dyer"
   },
   {
     "url": "https://www.puzzlescript.net/play.html?p=62070c89dc7604de2484",
-    "thumb": "62070c89dc7604de2484.gif"
+    "thumb": "62070c89dc7604de2484.gif",
+    "title": "Rock, Paper, Scissors",
+    "author": "chaotic_iak",
+    "homepage": "chaosatthesky.wordpress.com"
   },
   {
     "url": "https://www.puzzlescript.net/play.html?p=ed5ba4e63cf2c92788da",
-    "thumb": "ed5ba4e63cf2c92788da.gif"
+    "thumb": "ed5ba4e63cf2c92788da.gif",
+    "title": "Hazard Golf",
+    "author": "Mark Richardson"
   },
   {
     "url": "https://www.puzzlescript.net/play.html?p=fd4e3445b63068676f72",
-    "thumb": "fd4e3445b63068676f72.gif"
+    "thumb": "fd4e3445b63068676f72.gif",
+    "title": "Collapsable Sokoban",
+    "author": "Franklin P. Dyer"
   },
   {
     "url": "https://www.draknek.org/games/puzzlescript/skipping-stones.php",
-    "thumb": "stones.gif"
+    "thumb": "stones.gif",
+    "title": "Skipping Stones to Lonely Homes",
+    "author": "Alan Hazelden",
+    "homepage": "https://www.draknek.org"
   },
   {
     "url": "https://www.puzzlescript.net/play.html?p=09b30f559f01393008af",
-    "thumb": "09b30f559f01393008af.gif"
+    "thumb": "09b30f559f01393008af.gif",
+    "title": "the undertaking",
+    "author": "anna anthropy",
+    "homepage": "https://w.itch.io/"
   },
   {
     "url": "https://www.puzzlescript.net/play.html?p=1bca2d279640ab3839c0",
-    "thumb": "1bca2d279640ab3839c0.gif"
+    "thumb": "1bca2d279640ab3839c0.gif",
+    "title": "JAM3 Game",
+    "author": "chaotic_iak"
   },
   {
     "url": "https://www.puzzlescript.net/play.html?p=4e66fc851edbf42ae008",
-    "thumb": "4e66fc851edbf42ae008.gif"
+    "thumb": "4e66fc851edbf42ae008.gif",
+    "title": "Dharma Dojo demake",
+    "author": "Metro [cloned by CHz]",
+    "homepage": "quiteajolt.com"
   },
   {
     "url": "https://www.puzzlescript.net/play.html?p=c7da961162348381d271",
-    "thumb": "c7da961162348381d271.gif"
+    "thumb": "c7da961162348381d271.gif",
+    "title": "Vines",
+    "author": "Stefan Peeters"
   },
   {
     "url": "https://www.puzzlescript.net/play.html?p=f4959a4150da120e6117a8c4e7c1a69d",
-    "thumb": "f4959a4150da120e6117a8c4e7c1a69d.gif"
+    "thumb": "f4959a4150da120e6117a8c4e7c1a69d.gif",
+    "title": "Unconventional Guns",
+    "author": "rectangular Tim",
+    "homepage": "http://ludumdare.com/compo/ludum-dare-32/?action=preview&uid=39396"
   },
   {
     "url": "https://www.puzzlescript.net/play.html?p=9cf57ca82a0181de97e4e225bc9bf4ca",
-    "thumb": "9cf57ca82a0181de97e4e225bc9bf4ca.gif"
+    "thumb": "9cf57ca82a0181de97e4e225bc9bf4ca.gif",
+    "title": "Newton's Crates",
+    "author": "Andrey Shevchuk",
+    "homepage": "shevchuk.net"
   },
   {
     "url": "https://www.puzzlescript.net/play.html?p=ed8845d930c8940bef1236cf18ca5bd2",
-    "thumb": "ed8845d930c8940bef1236cf18ca5bd2.gif"
+    "thumb": "ed8845d930c8940bef1236cf18ca5bd2.gif",
+    "title": "Count Mover",
+    "author": "Jonah Ostroff"
   },
   {
     "url": "https://www.draknek.org/games/puzzlescript/boxing-gloves.php",
-    "thumb": "gloves.gif"
+    "thumb": "gloves.gif",
+    "title": "Boxes Love Boxing Gloves",
+    "author": "Alan Hazelden",
+    "homepage": "https://www.draknek.org"
   },
   {
     "url": "https://www.puzzlescript.net/play.html?p=b1de1cc4f616b950f59b52e703457a37",
-    "thumb": "b1de1cc4f616b950f59b52e703457a37.gif"
+    "thumb": "b1de1cc4f616b950f59b52e703457a37.gif",
+    "title": "Vacuum",
+    "author": "Mark Richardson"
   },
   {
     "url": "https://www.puzzlescript.net/play.html?p=1fa8e206e54b1a66926bec98d3df63cd",
-    "thumb": "1fa8e206e54b1a66926bec98d3df63cd.gif"
+    "thumb": "1fa8e206e54b1a66926bec98d3df63cd.gif",
+    "title": "ParaLands",
+    "author": "Lukas"
   },
   {
     "url": "https://www.puzzlescript.net/play.html?p=33eee323d8edfbdc20ee2d584cee2b4b",
-    "thumb": "33eee323d8edfbdc20ee2d584cee2b4b.gif"
+    "thumb": "33eee323d8edfbdc20ee2d584cee2b4b.gif",
+    "title": "Some lines were meant to be crossed",
+    "author": "Frpzzd"
   },
   {
     "url": "https://www.puzzlescript.net/play.html?p=14a2f967a1978e28e91118126ac22d6a",
-    "thumb": "14a2f967a1978e28e91118126ac22d6a.gif"
+    "thumb": "14a2f967a1978e28e91118126ac22d6a.gif",
+    "title": "Stand Off",
+    "author": "Mark Richardson"
   },
   {
     "url": "https://www.puzzlescript.net/play.html?p=e41e523af2fba4ac36f1f635d13654e3",
-    "thumb": "e41e523af2fba4ac36f1f635d13654e3.gif"
+    "thumb": "e41e523af2fba4ac36f1f635d13654e3.gif",
+    "title": "\ud83c\udf61 -ooo- \ud83c\udf61",
+    "author": "Baku",
+    "homepage": "http://baku89.com"
   },
   {
     "url": "https://www.puzzlescript.net/play.html?p=0f174b98074b628e8de5514c5839efae",
-    "thumb": "0f174b98074b628e8de5514c5839efae.gif"
+    "thumb": "0f174b98074b628e8de5514c5839efae.gif",
+    "title": "Rose"
   },
   {
     "url": "https://www.puzzlescript.net/play.html?p=d42bf2a870aab3a2deca6132ff6ebad5",
-    "thumb": "d42bf2a870aab3a2deca6132ff6ebad5.gif"
+    "thumb": "d42bf2a870aab3a2deca6132ff6ebad5.gif",
+    "title": "Season Finale"
   },
   {
     "url": "https://www.puzzlescript.net/play.html?p=fbbcdbcf3e28bc08fe953f8853446e9f",
-    "thumb": "fbbcdbcf3e28bc08fe953f8853446e9f.gif"
+    "thumb": "fbbcdbcf3e28bc08fe953f8853446e9f.gif",
+    "title": "Spider's Hollow",
+    "author": "John Thyer"
   },
   {
     "url": "https://www.puzzlescript.net/play.html?p=3a614a286aff60b6b3cd4032c1eb384b",
-    "thumb": "3a614a286aff60b6b3cd4032c1eb384b.gif"
+    "thumb": "3a614a286aff60b6b3cd4032c1eb384b.gif",
+    "title": "i herd u liek water templs",
+    "author": "Denis Prause",
+    "homepage": "https://twitter.com/zejety"
   },
   {
     "url": "https://heskhwis.itch.io/the-closet-and-the-castle",
-    "thumb": "castle.gif"
+    "thumb": "castle.gif",
+    "title": "The closet and the castle",
+    "author": "HeskHwis and Holly Hatter",
+    "homepage": "heskhwis.tumblr.com"
   },
   {
     "url": "https://heskhwis.itch.io/my-first-kishoutenketsu",
-    "thumb": "fish.gif"
+    "thumb": "fish.gif",
+    "title": "\"My first Kishoutenketsu\"",
+    "author": "HeskHwis",
+    "homepage": "heskhwis.tumblr.com"
   },
   {
     "url": "https://www.puzzlescript.net/play.html?p=983d3fe448e281182289826597fe5a4b",
-    "thumb": "983d3fe448e281182289826597fe5a4b.gif"
+    "thumb": "983d3fe448e281182289826597fe5a4b.gif",
+    "title": "PrograMaze",
+    "author": "Adam Gashlin",
+    "homepage": "gashlin.net"
   },
   {
     "url": "https://www.puzzlescript.net/play.html?p=57da05bc817b904d037df40fefa78d66",
-    "thumb": "57da05bc817b904d037df40fefa78d66.gif"
+    "thumb": "57da05bc817b904d037df40fefa78d66.gif",
+    "title": "Symbolism",
+    "author": "Richard Locke",
+    "homepage": "www.richardlocke.co.uk"
   },
   {
-    "url": "https://www.richardlocke.co.uk/release/entanglement/chapter-1/",
-    "thumb": "entanglement.gif"
+    "url": "https://virelsa.itch.io/entanglement-chapter-1",
+    "thumb": "entanglement.gif",
+    "title": "Entanglement - Chapter One",
+    "author": "Richard Locke",
+    "homepage": "www.richardlocke.co.uk"
   },
   {
     "url": "https://www.puzzlescript.net/play.html?p=ce2474f62432e2a703bba3fb65f5b01f",
-    "thumb": "ce2474f62432e2a703bba3fb65f5b01f.gif"
+    "thumb": "ce2474f62432e2a703bba3fb65f5b01f.gif",
+    "title": "Vertebrae",
+    "author": "Ali Nikkhah"
   },
   {
     "url": "https://rosden.itch.io/theflames",
-    "thumb": "flames.gif"
+    "thumb": "flames.gif",
+    "title": "The Flames",
+    "author": "Rosden Shadow [Mark Signorelli]",
+    "homepage": "rosden.itch.io"
   },
   {
     "url": "https://www.puzzlescript.net/play.html?p=0e692c47ab0b18099c2485d644590b4e",
-    "thumb": "0e692c47ab0b18099c2485d644590b4e.gif"
+    "thumb": "0e692c47ab0b18099c2485d644590b4e.gif",
+    "title": "Watch Your Step",
+    "author": "Aaron Steed"
   },
   {
     "url": "https://www.draknek.org/games/puzzlescript/spikes-n-stuff.php",
-    "thumb": "spikes.gif"
+    "thumb": "spikes.gif",
+    "title": "Spikes 'n' Stuff",
+    "author": "Alan Hazelden",
+    "homepage": "https://www.draknek.org"
   },
   {
     "url": "https://www.puzzlescript.net/play.html?p=537878634acb9aa4cfbd5298856ea1ef",
-    "thumb": "537878634acb9aa4cfbd5298856ea1ef.gif"
+    "thumb": "537878634acb9aa4cfbd5298856ea1ef.gif",
+    "title": "XL-Plan",
+    "author": "Mark Richardson"
   },
   {
     "url": "https://pedropsi.github.io/pmgrp#puzzlescript",
-    "thumb": "pmgrp.gif"
+    "thumb": "pmgrp.gif",
+    "title": "Play Mini Gemini Replay (PMGRP)",
+    "author": "Pedro PSI",
+    "homepage": "https://pedropsi.github.io/"
   },
   {
     "url": "https://www.puzzlescript.net/play.html?p=9ebe1e5ad44ac22259343de170a3b337",
-    "thumb": "9ebe1e5ad44ac22259343de170a3b337.gif"
+    "thumb": "9ebe1e5ad44ac22259343de170a3b337.gif",
+    "title": "Coin Counter"
   },
   {
     "url": "https://www.puzzlescript.net/play.html?p=a95269130d520a58adf710b692d1e52e",
-    "thumb": "a95269130d520a58adf710b692d1e52e.gif"
+    "thumb": "a95269130d520a58adf710b692d1e52e.gif",
+    "title": "Easy Enigma"
   },
   {
     "url": "https://www.puzzlescript.net/play.html?p=45f13378f02acf2d2583d91fac32e729",
-    "thumb": "45f13378f02acf2d2583d91fac32e729.gif"
+    "thumb": "45f13378f02acf2d2583d91fac32e729.gif",
+    "title": "the art of cloning",
+    "author": "Rosden Shadow [Mark Signorelli]",
+    "homepage": "rosden.itch.io"
   },
   {
     "url": "https://www.puzzlescript.net/play.html?p=3acdd359dea642168ff946bfc26f0152",
-    "thumb": "3acdd359dea642168ff946bfc26f0152.gif"
+    "thumb": "3acdd359dea642168ff946bfc26f0152.gif",
+    "title": "interconnection",
+    "author": "Rosden Shadow [Mark Signorelli]",
+    "homepage": "rosden.itch.io"
   },
   {
     "url": "https://www.puzzlescript.net/play.html?p=b1c07b54e2091c40221cf48fe66d25ab",
-    "thumb": "b1c07b54e2091c40221cf48fe66d25ab.gif"
+    "thumb": "b1c07b54e2091c40221cf48fe66d25ab.gif",
+    "title": "Path lines",
+    "author": "Rosden Shadow [Mark Signorelli]",
+    "homepage": "rosden.itch.io"
   },
   {
     "url": "https://chz.itch.io/maera-public-works",
-    "thumb": "public.gif"
+    "thumb": "public.gif",
+    "title": "Maera Public Works",
+    "author": "CHz",
+    "homepage": "quiteajolt.com"
   },
   {
     "url": "https://www.puzzlescript.net/play.html?p=a4bb2bf44284bdb9347cf3f1399d4f11",
-    "thumb": "a4bb2bf44284bdb9347cf3f1399d4f11.gif"
+    "thumb": "a4bb2bf44284bdb9347cf3f1399d4f11.gif",
+    "title": "I'm too far gone"
   },
   {
     "url": "https://www.puzzlescript.net/play.html?p=9eb8f8f3df4efb450b798a279eeba2e0",
-    "thumb": "9eb8f8f3df4efb450b798a279eeba2e0.gif"
+    "thumb": "9eb8f8f3df4efb450b798a279eeba2e0.gif",
+    "title": "VEXT EDIT",
+    "author": "JACK"
   },
   {
     "url": "https://www.puzzlescript.net/play.html?p=4adc7b17c2c0449c3a8b6c730e8cbfc9",
-    "thumb": "4adc7b17c2c0449c3a8b6c730e8cbfc9.gif"
+    "thumb": "4adc7b17c2c0449c3a8b6c730e8cbfc9.gif",
+    "title": "Soliquid",
+    "author": "Anton Klinger"
   },
   {
     "url": "https://www.puzzlescript.net/play.html?p=f7518dbe107486ab1a50e6119f4bc3f2",
-    "thumb": "f7518dbe107486ab1a50e6119f4bc3f2.gif"
+    "thumb": "f7518dbe107486ab1a50e6119f4bc3f2.gif",
+    "title": "Broken Abacus",
+    "author": "Le Slo",
+    "homepage": "le-slo.itch.io/"
   },
   {
     "url": "https://www.puzzlescript.net/play.html?p=7572972f749909993b12d84991e47ec9",
-    "thumb": "7572972f749909993b12d84991e47ec9.gif"
+    "thumb": "7572972f749909993b12d84991e47ec9.gif",
+    "title": "Mini Nomerads",
+    "author": "Dan Williams",
+    "homepage": "www.activeupgames.com"
   },
   {
     "url": "https://zacharybarbanell.itch.io/loop-deleter",
-    "thumb": "deleter.gif"
+    "thumb": "deleter.gif",
+    "title": "Loop Deleter",
+    "author": "Zachary Barbanell",
+    "homepage": "https://zacharybarbanell.itch.io/"
   },
   {
     "url": "https://www.puzzlescript.net/play.html?p=58325085befa37ab497168cd803c64cb",
-    "thumb": "58325085befa37ab497168cd803c64cb.gif"
+    "thumb": "58325085befa37ab497168cd803c64cb.gif",
+    "title": "Fall Leaves",
+    "author": "Le Slo"
   },
   {
     "url": "https://www.puzzlescript.net/play.html?p=8ba10d6a0a5a0edd640e0b9431858259",
-    "thumb": "8ba10d6a0a5a0edd640e0b9431858259.gif"
+    "thumb": "8ba10d6a0a5a0edd640e0b9431858259.gif",
+    "title": "Mad Queens",
+    "author": "Chris Pickel",
+    "homepage": "https://sfiera.net/"
   },
-  { 
+  {
     "url": "https://www.puzzlescript.net/play.html?p=35861399c74d3f57f39aaf64daadde65",
-    "thumb": "35861399c74d3f57f39aaf64daadde65.gif"
+    "thumb": "35861399c74d3f57f39aaf64daadde65.gif",
+    "title": "Indigestion",
+    "author": "Le Slo"
   },
   {
     "url": "https://thinkycollective.itch.io/ahoist-cratey",
-    "thumb": "ahoist.gif"
+    "thumb": "ahoist.gif",
+    "title": "Ahoist Cratey",
+    "author": "Thinky Collective",
+    "homepage": "https://thinkycollective.itch.io/"
   },
   {
     "url": "https://www.puzzlescript.net/play.html?p=2fe3172d2b9fe684977d184f1b6226d5",
-    "thumb":"2fe3172d2b9fe684977d184f1b6226d5.gif"
+    "thumb": "2fe3172d2b9fe684977d184f1b6226d5.gif",
+    "title": "Pushing It",
+    "author": "Jack Lance"
   },
 ]


### PR DESCRIPTION
Fixes #618

I scraped the puzzlescript files for the title/author/homepage metadata.
For games whose links don't include the gist ID in the URL, I added the info manually.

Script I used (after changing the data file to pure json): https://gist.github.com/salty-horse/938f36452720f48b4f1cbd0800d13d82

* In one case the homepage was just `@username` and the username no longer on Twitter, so I didn't add a homepage.
* In one case the URL for the homepage redirected improperly (the 1push demake), so I fixed it.
* I also updated a few homepage URLs to their new redirected page (e.g. auntiepixelante.com which now ieads to w.itch.io)
* https://www.richardlocke.co.uk/release/entanglement/chapter-1/ is not available. I updated it to https://virelsa.itch.io/entanglement-chapter-1
* www.richardlocke.co.uk is empty. Perhaps the homepage should lead to the author's itch page?
* There's an Entanglement Chapter 2 on the author's itch page that's not in the gallery.
* Ahoist Cratey linked to puzzlescript.net. I changed it to the author's itch page.

On a related note, I think it would be helpful to link somewhere to these two puzzlescript game sources:
* [Pedro PSI's puzzlescript database](https://pedropsi.github.io/puzzlescript-games-database.html)
* itch.io's [puzzlescript tag](https://itch.io/games/tag-puzzlescript) (although it has several incorrectly-tagged games)