### PR TITLE
fix gallery homepage links

### DIFF
--- a/src/index.html
+++ b/src/index.html
@@ -184,6 +184,9 @@ function replaceContent() {
     if (item.hasOwnProperty("homepage")===false){
       item.homepage=item.url;
     }
+    if (item.homepage.startsWith("http")===false){
+      item.homepage="https://"+item.homepage
+    }
     data.push(item);
   }
   data = shuffle(data);


### PR DESCRIPTION
links apparently need the protocol explicitly specified; otherwise, the browser tries to link you internally.

e.g. `"homepage": "www.increpare.com"` in the JSON was linking to "https://www.puzzlescript.net/Gallery/www.increpare.com" on the website

this should fix it? but I can't test it to be sure