### PR TITLE
Fix trailing whitespace and inconsistent casing in default project

### DIFF
--- a/src/editor.html
+++ b/src/editor.html
@@ -33,20 +33,20 @@ homepage www.puzzlescript.net
 OBJECTS
 ========
 
-Background 
-GREEN  
+Background
+Green
 
-Target 
-DarkBlue    
+Target
+DarkBlue
 
-Wall 
-BROWN
+Wall
+Brown
 
-Player 
-Blue   
+Player
+Blue
 
-Crate 
-Orange 
+Crate
+Orange
 
 =======
 LEGEND
@@ -72,18 +72,18 @@ Target
 Player, Wall, Crate
 
 ======
-RULES     
-======     
+RULES
+======
 
-[ >  Player | Crate ] -> [  >  Player | > Crate  ]     
+[ > Player | Crate ] -> [ > Player | > Crate ]
 
 ==============
 WINCONDITIONS
 ==============
 
-All Target on Crate     
+all Target on Crate
 
-=======     
+=======
 LEVELS
 =======
 

--- a/src/editor.html
+++ b/src/editor.html
@@ -81,7 +81,7 @@ RULES
 WINCONDITIONS
 ==============
 
-all Target on Crate
+All Target on Crate
 
 =======
 LEVELS


### PR DESCRIPTION
Disclaimer: case changes definitely based on subjective preference.