### PR TITLE
Added missing pushSoundToHistory function to debug_off.js

### DIFF
--- a/src/js/debug_off.js
+++ b/src/js/debug_off.js
@@ -43,3 +43,4 @@ function logErrorNoLine(str){
 
 function clearInputHistory() {}
 function pushInput(inp) {}
+function pushSoundToHistory(seed) {}


### PR DESCRIPTION
This function was referenced by sfxr.js, but was only defined in debug.js.  This caused breakage when trying to play sounds outside of the editor.

As an example, play any game with sound outside of the editor; e.g., https://www.puzzlescript.net/play.html?p=361283c1cef6837b6563d25e8f01e444.  When a sound would normally play as a result of a move, an error occurs due to the missing function being called.  This results in the sound not being played and the graphics not being updated for the move that triggered it.

This fixes the issue by adding a no-op version of the function to debug_off.js.

