### PR TITLE
smooth out framerate by replacing setTimeout() with requestAnimationFrame()

### DIFF
--- a/src/js/inputoutput.js
+++ b/src/js/inputoutput.js
@@ -801,8 +801,12 @@ function checkKey(e,justPressed) {
     }
 }
 
-
+// main loop! it'll repeat itself at 60fps
+//  (or the browser's refresh rate)
+// and will auto-pause when the tab loses focus
 function update() {
+    requestAnimationFrame(update);
+
     timer+=deltatime;
     input_throttle_timer+=deltatime;
     if (quittingTitleScreen) {
@@ -867,24 +871,4 @@ function update() {
     }
 }
 
-var looping=false;
-// Lights, camera…function!
-var loop = function(){
-	looping=true;
-	update();
-	if (document.visibilityState==='hidden'){
-		looping=false;
-		return;
-	};
-	setTimeout(loop,deltatime);
-}
-
-document.addEventListener('visibilitychange', function logData() {
-	if (document.visibilityState === 'visible') {
-		if (looping===false){
-			loop();
-		}
-	}
-  });
-
-loop();
+window.onload=update


### PR DESCRIPTION
## before this change
I noticed puzzlescript uses setTimeout() instead of [requestAnimationFrame()](https://developer.mozilla.org/en-US/docs/Web/API/window/requestAnimationFrame) for its main loop. I was curious what effect that had, so I opened up the browser devtools and did some profiling on a little test game: https://www.puzzlescript.net/editor.html?hack=a4cd79393efe4c5cf76b10669e553c08 

some notable things:
1. I'm requesting 100000 fps; good luck puzzlescript!
2. The actual fps is 60...
3. hmm but actually there are blips of 30fps...
4. every ~12 frames or so. this is probably related to the fact that puzzlescript uses `setTimeOut(loop,17)`, and 17 is slightly too high. I'm surprised it's that often though; shouldn't it be around every `16.6667/(17-16.6667)`=50 frames? or maybe half that, idk
5. there are also some completely dropped frames; not sure why 

![unknown](https://user-images.githubusercontent.com/11308928/172728063-9911c15d-f76a-4e90-9020-1d9344edcf95.png)

(That was tested on vanilla puzzlescript, at puzzlescript.net)

## after this change
After making the change in this PR locally, the graph looks like this instead:

![unknown](https://user-images.githubusercontent.com/11308928/172728095-b94dba34-d3b4-42d5-b7dc-3d1ab6d6a6e3.png)

hooray! 

## notes
- this preserves the "pause-when-tabbed-out" behavior automatically, because requestAnimationFrame is smart like that; the MDN link (above) says:
> The number of callbacks is usually 60 times per second, but will generally match the display refresh rate in most web browsers as per W3C recommendation. requestAnimationFrame() calls are paused in most browsers when running in background tabs or hidden [<iframe>](https://developer.mozilla.org/en-US/docs/Web/HTML/Element/iframe)s in order to improve performance and battery life.
- I didn't touch `deltatime=17`, but it should probably be changed to `deltatime=1000/60`... or maybe calculate the actual time taken on-the-fly? requestAnimationFrame() is "usually" 60fps but that's apparently not guaranteed, so calculating it might be good?
- I tested this change on a medium-sized puzzlescript game I have and it seemed to run fine
- I didn't run the inliner on this commit