### PR TITLE
Update Sprite Drawing

### DIFF
--- a/src/js/graphics.js
+++ b/src/js/graphics.js
@@ -10,9 +10,11 @@ function createSprite(name,spritegrid, colors, padding) {
 
 	var w = spritegrid[0].length;
 	var h = spritegrid.length;
-	var cw = ~~(cellwidth / (w + (padding|0)));
-    var ch = ~~(cellheight / (h + (padding|0)));
-    var pixh=ch;
+	var cw = cellwidth / (w + (padding|0));
+    var ch = cellheight / (h + (padding|0));
+	var pixw = Math.ceil(cw);
+	var pixh = Math.ceil(ch);
+	
     if ("scanline" in state.metadata) {
         pixh=Math.ceil(ch/2);
     }
@@ -24,7 +26,7 @@ function createSprite(name,spritegrid, colors, padding) {
                 var cy = (j * ch)|0;
                 var cx = (k * cw)|0;
                 spritectx.fillStyle = colors[val];
-                spritectx.fillRect(cx, cy, cw, pixh);
+                spritectx.fillRect(cx, cy, pixw, pixh);
             }
         }
     }


### PR DESCRIPTION
In drawing sprites of less than 5x5 pixels, the tile size was less than it should be. I tried to look at the parser.js but I don't feel like touching that, regex is my worst enemy 😆 
![image](https://user-images.githubusercontent.com/36713157/173724245-747b73a9-0ab1-435f-b528-07683b1a83c4.png)
Fixes #927 (kind of)