### PR TITLE
Support fetching gist with token when signed in

### DIFF
--- a/src/editor.html
+++ b/src/editor.html
@@ -199,6 +199,7 @@ LEVELS
 <script src="js/buildStandalone.js"></script>
 <script src="js/engine.js"></script>
 <script src="js/parser.js"></script>
+<script src="js/github.js"></script>
 <script src="js/editor.js"></script>
 <script src="js/compiler.js"></script>
 <script src="js/soundbar.js"></script>

--- a/src/js/editor.js
+++ b/src/js/editor.js
@@ -170,46 +170,19 @@ function getParameterByName(name) {
 }
 
 function tryLoadGist(id) {
-	var githubURL = 'https://api.github.com/gists/'+id;
-
-	consolePrint("Contacting GitHub",true);
-	var githubHTTPClient = new XMLHttpRequest();
-
-	githubHTTPClient.open('GET', githubURL);
-	githubHTTPClient.onreadystatechange = function() {
-	
-		if(githubHTTPClient.readyState!=4) {
+	github.load(id, function(code, e) {
+		if (e!==null) {
+			consoleError(e);
 			return;
 		}
-
-		if (githubHTTPClient.responseText==="") {
-			consoleError("GitHub request returned nothing.  A connection fault, maybe?");
-		}
-
-		var result = JSON.parse(githubHTTPClient.responseText);
-		if (githubHTTPClient.status===403) {
-			consoleError(result.message);
-		} else if (githubHTTPClient.status!==200&&githubHTTPClient.status!==201) {
-			consoleError("HTTP Error "+ githubHTTPClient.status + ' - ' + githubHTTPClient.statusText);
-		} else {
-			var code=result["files"]["script.txt"]["content"];
-			editor.setValue(code);
-			editor.clearHistory();
-			clearConsole();
-			setEditorClean();
-			unloadGame();
-			compile(["restart"],code);
-		}
-	}
-	// if (storage_has('oauth_access_token')) {
-    //     var oauthAccessToken = storage_get("oauth_access_token");
-    //     if (typeof oauthAccessToken === "string") {
-    //         githubHTTPClient.setRequestHeader("Authorization","token "+oauthAccessToken);
-    //     }
-    // }
-	githubHTTPClient.setRequestHeader("Content-type","application/x-www-form-urlencoded");
-	githubHTTPClient.send();
-}
+		editor.setValue(code);
+		editor.clearHistory();
+		clearConsole();
+		setEditorClean();
+		unloadGame();
+		compile(["restart"],code);
+	});
+};
 
 function tryLoadFile(fileName) {
 	var fileOpenClient = new XMLHttpRequest();

--- a/src/js/editor.js
+++ b/src/js/editor.js
@@ -170,7 +170,7 @@ function getParameterByName(name) {
 }
 
 function tryLoadGist(id) {
-	github.load(id, function(code, e) {
+	github_load(id, function(code, e) {
 		if (e!==null) {
 			consoleError(e);
 			return;

--- a/src/js/github.js
+++ b/src/js/github.js
@@ -1,0 +1,111 @@
+github = {};
+
+// The client ID of a GitHub OAuth app registered at https://github.com/settings/developers.
+// The “callback URL” of that app points to https://www.puzzlescript.net/auth.html.
+// If you’re running from another host name, sharing might not work.
+OAUTH_CLIENT_ID = "211570277eb588cddf44";
+
+github.authURL = function() {
+	// Generates 32 letters of random data, like "liVsr/e+luK9tC02fUob75zEKaL4VpQn".
+	var randomState = window.btoa(Array.prototype.map.call(
+		window.crypto.getRandomValues(new Uint8Array(24)),
+		function(x) { return String.fromCharCode(x); }).join(""));
+
+	return "https://github.com/login/oauth/authorize"
+		+ "?client_id=" + OAUTH_CLIENT_ID
+		+ "&scope=gist"
+		+ "&state=" + randomState
+		+ "&allow_signup=true";
+};
+
+github.signOut = function() {
+	storage_remove("oauth_access_token");
+};
+
+github.isSignedIn = function() {
+	var token = storage_get("oauth_access_token");
+	return typeof token === "string";
+};
+
+github.load = function(id, done) { 
+	var githubURL = "https://api.github.com/gists/"+id;
+
+	var githubHTTPClient = new XMLHttpRequest();
+	githubHTTPClient.open("GET", githubURL);
+	githubHTTPClient.onreadystatechange = function() {
+		if (githubHTTPClient.readyState!=4) {
+			return;
+		} else if (githubHTTPClient.responseText==="") {
+			done(null, "GitHub request returned nothing.  A connection fault, maybe?");
+			return;
+		}
+
+		var result = JSON.parse(githubHTTPClient.responseText);
+		if (githubHTTPClient.status===403) {
+			done(null, result.message);
+			return;
+		} else if (githubHTTPClient.status!==200 && githubHTTPClient.status!==201) {
+			done(null, "HTTP Error "+ githubHTTPClient.status + " - " + githubHTTPClient.statusText);
+			return;
+		}
+		var result = JSON.parse(githubHTTPClient.responseText);
+		var code=result["files"]["script.txt"]["content"];
+		done(code, null);
+	}
+
+	// if (storage_has("oauth_access_token")) {
+	//     var oauthAccessToken = storage_get("oauth_access_token");
+	//     if (typeof oauthAccessToken === "string") {
+	//         githubHTTPClient.setRequestHeader("Authorization","token "+oauthAccessToken);
+	//     }
+	// }
+	githubHTTPClient.setRequestHeader("Content-type", "application/x-www-form-urlencoded");
+	githubHTTPClient.send();
+};
+
+github.save = function(title, code, done) {
+	var oauthAccessToken = storage_get("oauth_access_token");
+	if (typeof oauthAccessToken !== "string") {
+		printUnauthorized();
+		return;
+	}
+
+	var gistToCreate = {
+		"description" : title,
+		"public" : true,
+		"files": {
+			"readme.txt" : {
+				"content": "Play this game by pasting the script in http://www.puzzlescript.net/editor.html"
+			},
+			"script.txt" : {
+				"content": code
+			}
+		}
+	};
+
+	var githubURL = "https://api.github.com/gists";
+	var githubHTTPClient = new XMLHttpRequest();
+	githubHTTPClient.open("POST", githubURL);
+	githubHTTPClient.onreadystatechange = function() {		
+		if(githubHTTPClient.readyState!=4) {
+			return;
+		}		
+		var result = JSON.parse(githubHTTPClient.responseText);
+		if (githubHTTPClient.status===403) {
+			done(null, result.message);
+		} else if (githubHTTPClient.status!==200&&githubHTTPClient.status!==201) {
+			github.signOut();
+			if (githubHTTPClient.statusText==="Unauthorized"){
+				done(null, "Authorization check failed.  You have to log back into GitHub (or give it permission again or something).");
+			} else {
+				done(null, "HTTP Error "+ githubHTTPClient.status + " - " + githubHTTPClient.statusText + ".  Try giving puzzlescript permission again, that might fix things...");
+			}
+		} else {
+			done(result.id, null);
+		}
+	}
+	githubHTTPClient.setRequestHeader("Content-type", "application/x-www-form-urlencoded");
+	githubHTTPClient.setRequestHeader("Authorization", "Token "+oauthAccessToken);
+	var stringifiedGist = JSON.stringify(gistToCreate);
+	githubHTTPClient.send(stringifiedGist);
+};

--- a/src/js/github.js
+++ b/src/js/github.js
@@ -1,11 +1,9 @@
-github = {};
-
 // The client ID of a GitHub OAuth app registered at https://github.com/settings/developers.
 // The “callback URL” of that app points to https://www.puzzlescript.net/auth.html.
 // If you’re running from another host name, sharing might not work.
 OAUTH_CLIENT_ID = "211570277eb588cddf44";
 
-github.authURL = function() {
+function github_authURL() {
 	// Generates 32 letters of random data, like "liVsr/e+luK9tC02fUob75zEKaL4VpQn".
 	var randomState = window.btoa(Array.prototype.map.call(
 		window.crypto.getRandomValues(new Uint8Array(24)),
@@ -18,16 +16,16 @@ github.authURL = function() {
 		+ "&allow_signup=true";
 };
 
-github.signOut = function() {
+function github_signOut{
 	storage_remove("oauth_access_token");
 };
 
-github.isSignedIn = function() {
+function github_isSignedIn() {
 	var token = storage_get("oauth_access_token");
 	return typeof token === "string";
 };
 
-github.load = function(id, done) { 
+function github_load(id, done) { 
 	var githubURL = "https://api.github.com/gists/"+id;
 
 	var githubHTTPClient = new XMLHttpRequest();
@@ -47,13 +45,13 @@ github.load = function(id, done) {
 
 		var result = JSON.parse(githubHTTPClient.responseText);
 		if (githubHTTPClient.status===403) {
-			if (!github.isSignedIn() && (result.message.indexOf("rate limit") !== -1)) {
+			if (!github_isSignedIn() && (result.message.indexOf("rate limit") !== -1)) {
 				done(null, "Exceeded GitHub rate limits. Try signing in from the editor.");
 			} else {
 				done(null, result.message);
 			}
 		} else if (githubHTTPClient.status===401) {
-			github.signOut();
+			github_signOut();
 			done(null, "Authorization check failed.  Try reloading or signing back in from the editor.");
 		} else if (githubHTTPClient.status>=500) {
 			done(null, "HTTP Error "+ githubHTTPClient.status + " - " + githubHTTPClient.statusText + ".");
@@ -66,7 +64,7 @@ github.load = function(id, done) {
 		}
 	}
 
-	if (github.isSignedIn()) {
+	if (github_isSignedIn()) {
 		var oauthAccessToken = storage_get("oauth_access_token");
 		githubHTTPClient.setRequestHeader("Authorization", "Token "+oauthAccessToken);
 	}
@@ -74,7 +72,7 @@ github.load = function(id, done) {
 	githubHTTPClient.send();
 };
 
-github.save = function(title, code, done) {
+function github_save(title, code, done) {
 	var oauthAccessToken = storage_get("oauth_access_token");
 	if (typeof oauthAccessToken !== "string") {
 		printUnauthorized();
@@ -105,12 +103,12 @@ github.save = function(title, code, done) {
 		if (githubHTTPClient.status===403) {
 			done(null, result.message);
 		} else if (githubHTTPClient.status===401) {
-			github.signOut();
+			github_signOut();
 			done(null, "Authorization check failed.  You have to log back into GitHub (or give it permission again or something).");
 		} else if (githubHTTPClient.status>=500) {
 			done(null, "HTTP Error "+ githubHTTPClient.status + " - " + githubHTTPClient.statusText + ".");
 		} else if (githubHTTPClient.status!==200 && githubHTTPClient.status!==201) {
-			github.signOut();
+			github_signOut();
 			done(null, "HTTP Error "+ githubHTTPClient.status + " - " + githubHTTPClient.statusText + ".  Try giving puzzlescript permission again, that might fix things...");
 		} else {
 			done(result.id, null);

--- a/src/js/toolbar.js
+++ b/src/js/toolbar.js
@@ -178,7 +178,7 @@ function levelEditorClick_Fn() {
 }
 
 function printUnauthorized(){
-	var authUrl = github.authURL();
+	var authUrl = github_authURL();
 	consolePrint(
 			"<br>" +
 			"PuzzleScript needs permission to share games through GitHub:<br>" +
@@ -188,7 +188,7 @@ function printUnauthorized(){
 }
 
 function shareClick() {
-	if (!github.isSignedIn()) {
+	if (!github_isSignedIn()) {
 		printUnauthorized();
 		return;
 	}
@@ -202,10 +202,10 @@ function shareClick() {
 	compile(["rebuild"]);
 
 	var source=editor.getValue();
-	github.save(title, source, function(id, e) {
+	github_save(title, source, function(id, e) {
 		if (e !== null) {
 			consoleError(e);
-			if (!github.isSignedIn()) {
+			if (!github_isSignedIn()) {
 				printUnauthorized();
 			}
 			return;
@@ -229,9 +229,9 @@ function shareClick() {
 }
 
 function githubLogOut(){
-	github.signOut();
+	github_signOut();
 
-	var authUrl = github.authURL();
+	var authUrl = github_authURL();
 	consolePrint(
 		"<br>Logged out of Github.<br>" +
 		"<ul>" +

--- a/src/js/toolbar.js
+++ b/src/js/toolbar.js
@@ -1,8 +1,3 @@
-// The client ID of a GitHub OAuth app registered at https://github.com/settings/developers.
-// The “callback URL” of that app points to https://www.puzzlescript.net/auth.html.
-// If you’re running from another host name, sharing might not work.
-
-
 function runClick() {
 	clearConsole();
 	compile(["restart"]);
@@ -182,25 +177,8 @@ function levelEditorClick_Fn() {
     lastDownTarget=canvas;	
 }
 
-OAUTH_CLIENT_ID = "211570277eb588cddf44";
-
-function getAuthURL(){
-	var randomState = window.btoa(Array.prototype.map.call(
-		window.crypto.getRandomValues(new Uint8Array(24)),
-		function(x) { return String.fromCharCode(x); }).join(""));
-
-	var authUrl = "https://github.com/login/oauth/authorize"
-		+ "?client_id=" + OAUTH_CLIENT_ID
-		+ "&scope=gist"
-		+ "&state=" + randomState
-		+ "&allow_signup=true";
-
-	return authUrl;
-}
-
 function printUnauthorized(){
-
-	var authUrl = getAuthURL();
+	var authUrl = github.authURL();
 	consolePrint(
 			"<br>" +
 			"PuzzleScript needs permission to share games through GitHub:<br>" +
@@ -210,9 +188,7 @@ function printUnauthorized(){
 }
 
 function shareClick() {
-	var oauthAccessToken = storage_get("oauth_access_token");
-	if (typeof oauthAccessToken !== "string") {
-		// Generates 32 letters of random data, like "liVsr/e+luK9tC02fUob75zEKaL4VpQn".
+	if (!github.isSignedIn()) {
 		printUnauthorized();
 		return;
 	}
@@ -225,76 +201,37 @@ function shareClick() {
 	
 	compile(["rebuild"]);
 
-
 	var source=editor.getValue();
-
-	var gistToCreate = {
-		"description" : title,
-		"public" : true,
-		"files": {
-			"readme.txt" : {
-				"content": "Play this game by pasting the script in http://www.puzzlescript.net/editor.html"
-			},
-			"script.txt" : {
-				"content": source
+	github.save(title, source, function(id, e) {
+		if (e !== null) {
+			consoleError(e);
+			if (!github.isSignedIn()) {
+				printUnauthorized();
 			}
-		}
-	};
-
-	var githubURL = 'https://api.github.com/gists';
-	var githubHTTPClient = new XMLHttpRequest();
-	githubHTTPClient.open('POST', githubURL);
-	githubHTTPClient.onreadystatechange = function() {		
-		if(githubHTTPClient.readyState!=4) {
 			return;
-		}		
-		var result = JSON.parse(githubHTTPClient.responseText);
-		if (githubHTTPClient.status===403) {
-			consoleError(result.message);
-		} else if (githubHTTPClient.status!==200&&githubHTTPClient.status!==201) {
-			if (githubHTTPClient.statusText==="Unauthorized"){
-				consoleError("Authorization check failed.  You have to log back into GitHub (or give it permission again or something).");
-				storage_remove("oauth_access_token");
-			} else {
-				consoleError("HTTP Error "+ githubHTTPClient.status + ' - ' + githubHTTPClient.statusText);
-				consoleError("Try giving puzzlescript permission again, that might fix things...");
-			}
-
-			printUnauthorized();
-		} else {
-			var id = result.id;
-			var url = "play.html?p="+id;
-			url=qualifyURL(url);
-
-			var editurl = "editor.html?hack="+id;
-			editurl=qualifyURL(editurl);
-			var sourceCodeLink = "Link to source code:<br><a target=\"_blank\"  href=\""+editurl+"\">"+editurl+"</a>";
-
-
-			consolePrint('GitHub (<a onclick="githubLogOut();"  href="javascript:void(0);">log out</a>) submission successful.<br>',true);
-
-			consolePrint('<br>'+sourceCodeLink,true);
-
-
-			if (errorCount>0) {
-				consolePrint("<br>Cannot link directly to playable game, because there are compiler errors.",true);
-			} else {
-				consolePrint("<br>The game can now be played at this url:<br><a target=\"_blank\" href=\""+url+"\">"+url+"</a>",true);
-			} 
-
 		}
-	}
-	githubHTTPClient.setRequestHeader("Content-type","application/x-www-form-urlencoded");
-	githubHTTPClient.setRequestHeader("Authorization","token "+oauthAccessToken);
-	var stringifiedGist = JSON.stringify(gistToCreate);
-	githubHTTPClient.send(stringifiedGist);
-    lastDownTarget=canvas;	
+
+		var url = qualifyURL("play.html?p="+id);
+		var editurl = qualifyURL("editor.html?hack="+id);
+		var sourceCodeLink = "Link to source code:<br><a target=\"_blank\"  href=\""+editurl+"\">"+editurl+"</a>";
+
+		consolePrint('GitHub (<a onclick="githubLogOut();"  href="javascript:void(0);">log out</a>) submission successful.<br>',true);
+		consolePrint('<br>'+sourceCodeLink,true);
+
+
+		if (errorCount>0) {
+			consolePrint("<br>Cannot link directly to playable game, because there are compiler errors.",true);
+		} else {
+			consolePrint("<br>The game can now be played at this url:<br><a target=\"_blank\" href=\""+url+"\">"+url+"</a>",true);
+		} 
+	});
+	lastDownTarget=canvas;	
 }
 
 function githubLogOut(){
-	storage_remove("oauth_access_token");
+	github.signOut();
 
-	var authUrl = getAuthURL();
+	var authUrl = github.authURL();
 	consolePrint(
 		"<br>Logged out of Github.<br>" +
 		"<ul>" +

--- a/src/play.html
+++ b/src/play.html
@@ -258,6 +258,7 @@ a {
 <script src="js/compiler.js"></script>
 <script src="js/inputoutput.js"></script>
 <script src="js/mobile.js"></script>
+<script src="js/github.js"></script>
 
 <script>
 
@@ -284,23 +285,11 @@ function getData(){
 		displayError("No ID specified in URL.")
 		return;
 	}
-
-	var githubURL = 'https://api.github.com/gists/'+id;
-
-	var githubHTTPClient = new XMLHttpRequest();
-	githubHTTPClient.open('GET', githubURL);
-	githubHTTPClient.onreadystatechange = function() {
-		if(githubHTTPClient.readyState!=4) {
+	github.load(id, function(code, e) {
+		if (e!==null) {
+			displayError(e);
 			return;
-		}		
-		var result = JSON.parse(githubHTTPClient.responseText);
-		if (githubHTTPClient.status===403) {
-			displayError(result.message);
-		} else if (githubHTTPClient.status!==200&&githubHTTPClient.status!==201) {
-			displayError("HTTP Error "+ githubHTTPClient.status + ' - ' + githubHTTPClient.statusText);
 		}
-		var result = JSON.parse(githubHTTPClient.responseText);
-		var code=result["files"]["script.txt"]["content"];
 		compile(["restart"],code);
 
 		if (state.metadata.homepage!==undefined) {
@@ -334,16 +323,7 @@ function getData(){
 		url=qualifyURL(url);
 
 		hacklink.href=url;
-        
-	}
-    // if (storage_has('oauth_access_token')) {
-    //     var oauthAccessToken = storage_get("oauth_access_token");
-    //     if (typeof oauthAccessToken === "string") {
-    //         githubHTTPClient.setRequestHeader("Authorization","token "+oauthAccessToken);
-    //     }
-    // }
-	githubHTTPClient.setRequestHeader("Content-type","application/x-www-form-urlencoded");
-	githubHTTPClient.send();
+	});
 }
 
 getData();


### PR DESCRIPTION
First, move all the GitHub code into its own `js/github.js` file. Both the player and editor can use the same basic code for loading gists.

Second, support using the token if it’s available. If there’s ever a 401 error when loading or saving a gist, remove the token and tell the user. In the case of loading, it might just be enough to reload (now that the user is signed out, the gist with be loaded with the non-token path).

Detect when there is a rate-limit error loading the game. Tell the user they can try signing in to the editor. For diagnostics, print the rate limit header info to the console log (it looks like: `Rate limit used 15/5000 (resets 2022-09-04T15:30:38.000Z)`).

This was previously implemented in #606 but later reverted in #689 because it didn’t handle 401 errors.