### PR TITLE
switch to requestAnimationFrame() for drawing

### DIFF
--- a/src/js/globalVariables.js
+++ b/src/js/globalVariables.js
@@ -35,7 +35,6 @@ var throttle_movement=false;
 var cache_console_messages=false;
 var quittingTitleScreen=false;
 var quittingMessageScreen=false;
-var deltatime=17;
 var timer=0;
 var repeatinterval=150;
 var autotick=0;

--- a/src/js/inputoutput.js
+++ b/src/js/inputoutput.js
@@ -801,11 +801,15 @@ function checkKey(e,justPressed) {
     }
 }
 
-// main loop! it'll repeat itself at 60fps
-//  (or the browser's refresh rate)
+// main loop! it'll repeat itself at the browser's refresh rate (generally 60fps)
 // and will auto-pause when the tab loses focus
-function update() {
-    requestAnimationFrame(update);
+var prevTimestamp;
+function loop(timestamp) {
+    var deltatime = 0
+    if (prevTimestamp !== undefined) {
+        deltatime = timestamp - prevTimestamp;
+    }
+    prevTimestamp = timestamp
 
     timer+=deltatime;
     input_throttle_timer+=deltatime;
@@ -869,6 +873,7 @@ function update() {
             }
         }
     }
+    window.requestAnimationFrame(loop);
 }
 
-window.onload=update
+window.requestAnimationFrame(loop);

--- a/src/js/inputoutput.js
+++ b/src/js/inputoutput.js
@@ -801,8 +801,12 @@ function checkKey(e,justPressed) {
     }
 }
 
-
+// main loop! it'll repeat itself at 60fps
+//  (or the browser's refresh rate)
+// and will auto-pause when the tab loses focus
 function update() {
+    requestAnimationFrame(update);
+
     timer+=deltatime;
     input_throttle_timer+=deltatime;
     if (quittingTitleScreen) {
@@ -867,24 +871,4 @@ function update() {
     }
 }
 
-var looping=false;
-// Lights, camera…function!
-var loop = function(){
-	looping=true;
-	update();
-	if (document.visibilityState==='hidden'){
-		looping=false;
-		return;
-	};
-	setTimeout(loop,deltatime);
-}
-
-document.addEventListener('visibilitychange', function logData() {
-	if (document.visibilityState === 'visible') {
-		if (looping===false){
-			loop();
-		}
-	}
-  });
-
-loop();
+window.onload=update


### PR DESCRIPTION
This is essentially the same code as #924, with this additional code to make sure `deltatime` is accurate

```js
var prevTimestamp;
function loop(timestamp) {
    var deltatime = 0
    if (prevTimestamp !== undefined) {
        deltatime = timestamp - prevTimestamp;
    }
    prevTimestamp = timestamp
```

This was the solution suggested by the [docs](https://developer.mozilla.org/en-US/docs/Web/API/window/requestAnimationFrame); I should have seen it and included it last time!

> Warning: Be sure to always use the first argument (or some other method for getting the current time) to calculate how much the animation will progress in a frame, otherwise the animation will run faster on high refresh rate screens. Check the example below for a way to do this.
