### PR TITLE
Fix syntax highlighting of colors in prelude

### DIFF
--- a/src/js/parser.js
+++ b/src/js/parser.js
@@ -1573,9 +1573,8 @@ var codeMirrorFn = function() {
                         stream.match(reg_notcommentstart, true);
                         state.tokenIndex++;
 
-                        var key = state [state.metadata.length-3];
-                        var val = state.metadata[state.metadata.length-2];
-                        var oldLineNum = state.metadata[state.metadata.length-1];
+                        var key = state.metadata[state.metadata.length-2];
+                        var val = state.metadata[state.metadata.length-1];
 
                         if( state.tokenIndex>2){
                             logWarning("Error: you can't embed comments in metadata values. Anything after the comment will be ignored.",state.lineNumber);


### PR DESCRIPTION
I was reading through the parser code and noticed this bit of code seemed to be broken.

Previous syntax highlighting:

<img width="337" alt="Screenshot 2023-04-08 at 16 28 16" src="https://user-images.githubusercontent.com/32490/230729604-6b7cc2bb-5e3e-437c-8d95-6690bb046291.png">

Fixed syntax highlighting:

<img width="338" alt="Screenshot 2023-04-08 at 16 29 19" src="https://user-images.githubusercontent.com/32490/230729670-c636da8f-181c-4861-96c7-fa571cc69594.png">

