### PR TITLE
Further abstract storage API

### DIFF
--- a/src/js/engine.js
+++ b/src/js/engine.js
@@ -2881,9 +2881,9 @@ function processInput(dir,dontDoWin,dontModify) {
 				restartTarget=level4Serialization();
 				hasUsedCheckpoint=true;
 				var backupStr = JSON.stringify(restartTarget);
-				storage_set(document.URL+'_checkpoint',backupStr);
-				storage_set(document.URL,curlevel);				
-			}	 
+				storage_set('_checkpoint',backupStr);
+				storage_set('',curlevel);
+			}
 
 		    if (level.commandQueue.indexOf('again')>=0 && modified) {
 
@@ -3094,8 +3094,8 @@ function nextLevel() {
 			}
 		} else {
 			try{
-				storage_remove(document.URL);
-				storage_remove(document.URL+'_checkpoint');				
+				storage_remove('');
+				storage_remove('_checkpoint');				
 			} catch(ex){
 					
 			}
@@ -3109,13 +3109,13 @@ function nextLevel() {
 	}
 	try {
 		
-		storage_set(document.URL,curlevel);
+		storage_set('',curlevel);
 		if (curlevelTarget!==null){
 			restartTarget=level4Serialization();
 			var backupStr = JSON.stringify(restartTarget);
-			storage_set(document.URL+'_checkpoint',backupStr);
+			storage_set('_checkpoint',backupStr);
 		} else {
-			storage_remove(document.URL+"_checkpoint");
+			storage_remove("_checkpoint");
 		}		
 		
 	} catch (ex) {

--- a/src/js/globalVariables.js
+++ b/src/js/globalVariables.js
@@ -9,9 +9,9 @@ var ignoreNotJustPressedAction=true;
 
 function doSetupTitleScreenLevelContinue(){
     try {
-        if (storage_has(document.URL)) {
-            if (storage_has(document.URL+'_checkpoint')){
-                var backupStr = storage_get(document.URL+'_checkpoint');
+        if (storage_has('')) {
+            if (storage_has('_checkpoint')){
+                var backupStr = storage_get('_checkpoint');
                 curlevelTarget = JSON.parse(backupStr);
                 
                 var arr = [];
@@ -21,7 +21,7 @@ function doSetupTitleScreenLevelContinue(){
                 curlevelTarget.dat = new Int32Array(arr);
 
             }
-            curlevel = storage_get(document.URL); 
+            curlevel = storage_get(''); 
         }
     } catch(ex) {
     }

--- a/src/js/storagewrapper.js
+++ b/src/js/storagewrapper.js
@@ -1,15 +1,15 @@
 function storage_has(key){
-    return localStorage.getItem(key)!==null;
+    return localStorage.getItem(document.URL+key)!==null;
 }
 
 function storage_get(key){
-    return localStorage.getItem(key);
+    return localStorage.getItem(document.URL+key);
 }
 
 function storage_set(key,value){
-    return localStorage.setItem(key,value);
+    return localStorage.setItem(document.URL+key,value);
 }
 
 function storage_remove(key){
-    localStorage.removeItem(key);
+    localStorage.removeItem(document.URL+key);
 }

--- a/src/standalone_inlined.txt
+++ b/src/standalone_inlined.txt
@@ -272,9 +272,9 @@ var ignoreNotJustPressedAction=true;
 
 function doSetupTitleScreenLevelContinue(){
     try {
-        if (storage_has(document.URL)) {
-            if (storage_has(document.URL+'_checkpoint')){
-                var backupStr = storage_get(document.URL+'_checkpoint');
+        if (storage_has('')) {
+            if (storage_has('_checkpoint')){
+                var backupStr = storage_get('_checkpoint');
                 curlevelTarget = JSON.parse(backupStr);
                 
                 var arr = [];
@@ -284,7 +284,7 @@ function doSetupTitleScreenLevelContinue(){
                 curlevelTarget.dat = new Int32Array(arr);
 
             }
-            curlevel = storage_get(document.URL); 
+            curlevel = storage_get(''); 
         }
     } catch(ex) {
     }
@@ -10068,7 +10068,7 @@ function processInput(dir,dontDoWin,dontModify) {
 				restartTarget=level4Serialization();
 				hasUsedCheckpoint=true;
 				var backupStr = JSON.stringify(restartTarget);
-				storage_set(document.URL+'_checkpoint',backupStr);
+				storage_set('_checkpoint',backupStr);
 				storage_set(document.URL,curlevel);				
 			}	 
 
@@ -10281,8 +10281,8 @@ function nextLevel() {
 			}
 		} else {
 			try{
-				storage_remove(document.URL);
-				storage_remove(document.URL+'_checkpoint');				
+				storage_remove('');
+				storage_remove('_checkpoint');				
 			} catch(ex){
 					
 			}
@@ -10300,9 +10300,9 @@ function nextLevel() {
 		if (curlevelTarget!==null){
 			restartTarget=level4Serialization();
 			var backupStr = JSON.stringify(restartTarget);
-			storage_set(document.URL+'_checkpoint',backupStr);
+			storage_set('_checkpoint',backupStr);
 		} else {
-			storage_remove(document.URL+"_checkpoint");
+			storage_remove("_checkpoint");
 		}		
 		
 	} catch (ex) {


### PR DESCRIPTION
Some platforms, notably the iOS simulator, change `document.URL` on every run, resulting in lost data.

Moving `document.URL` into `storagewrapper.js` allows for:
1. Cleaner calls in `engine.js` and `globalVariables.js`
2. Simpler overriding as now only the key is included in the call.

This change should have no effect on existing installations since the underlying localStorage keys remain the same.