### PR TITLE
fix data type inconsistency in spritematrix

### DIFF
--- a/src/js/compiler.js
+++ b/src/js/compiler.js
@@ -32,7 +32,7 @@ function generateSpriteMatrix(dat) {
             if (ch === '.') {
                 row.push(-1);
             } else {
-                row.push(ch);
+                row.push(parseInt(ch));
             }
         }
         result.push(row);


### PR DESCRIPTION
Before fix:
<img width="724" height="472" alt="image" src="https://github.com/user-attachments/assets/ade8c31a-863c-47eb-b7a0-778ceaeee621" />
