### PR TITLE
[codex] add static PuzzleScript analyzer

### DIFF
--- a/src/canonicalize.js
+++ b/src/canonicalize.js
@@ -197,6 +197,18 @@ globalThis.__ps_exports = {
                 errorCount: errorCount,
                 errorStrings: errorStrings.slice()
             };
+        } catch (error) {
+            const message = error && error.message ? error.message : String(error);
+            const errors = errorStrings.slice();
+            if (errors.indexOf(message) < 0) {
+                errors.push(message);
+            }
+            return {
+                state: null,
+                errorCount: errorCount > 0 ? errorCount : errors.length,
+                errorStrings: errors,
+                thrown: true
+            };
         } finally {
             compiling = false;
         }

--- a/src/canonicalize.js
+++ b/src/canonicalize.js
@@ -1034,6 +1034,17 @@ function canonicalizeSource(source, mode = 'structural') {
     return canonicalizeState(parsed.state, options);
 }
 
+function compileSemanticSource(source, options = {}) {
+    const includeWinConditions = options.includeWinConditions !== false;
+    const throwOnError = options.throwOnError !== false;
+    const compiled = getRuntime().compileSemantic(source, includeWinConditions);
+    if (throwOnError && (compiled.errorCount > 0 || compiled.state === null || compiled.state.invalid)) {
+        const message = compiled.errorStrings.join('\n');
+        throw new Error(`Unable to compile PuzzleScript source.\n${message}`);
+    }
+    return compiled;
+}
+
 function stableStringify(value) {
     return JSON.stringify(value, null, 2);
 }
@@ -1060,6 +1071,7 @@ module.exports = {
     buildComparisonHashes,
     canonicalizeFile,
     canonicalizeSource,
+    compileSemanticSource,
     hashCanonical,
     stableStringify,
 };

--- a/src/canonicalize.js
+++ b/src/canonicalize.js
@@ -199,6 +199,9 @@ globalThis.__ps_exports = {
             };
         } catch (error) {
             const message = error && error.message ? error.message : String(error);
+            if (message !== "Too many errors/warnings; aborting compilation.") {
+                throw error;
+            }
             const errors = errorStrings.slice();
             if (errors.indexOf(message) < 0) {
                 errors.push(message);

--- a/src/tests/canonicalizer_node.js
+++ b/src/tests/canonicalizer_node.js
@@ -6,6 +6,7 @@ const assert = require('assert');
 const {
     buildComparisonHashes,
     canonicalizeSource,
+    compileSemanticSource,
     hashCanonical,
 } = require('../canonicalize');
 
@@ -81,6 +82,15 @@ P.G
 ...
 ...
 `;
+
+const compiledBase = compileSemanticSource(baseGame);
+assert.strictEqual(compiledBase.errorCount, 0, 'compileSemanticSource should compile valid source');
+assert.ok(compiledBase.state, 'compileSemanticSource should return compiled state');
+assert.ok(compiledBase.state.objects.hero, 'compiled state should expose normalized compiler object names');
+assert.strictEqual(compiledBase.state.original_case_names.hero, 'Hero', 'compiled state should retain original object casing');
+assert.ok(Array.isArray(compiledBase.state.rules), 'compiled state should expose processed rules');
+assert.ok(compiledBase.state.rules.some(rule => rule.lineNumber), 'compiled rules should retain source line numbers');
+assert.ok(Array.isArray(compiledBase.state.winconditions), 'compiled state should expose processed win conditions');
 
 const renamedAndReskinned = `
 (comment)

--- a/src/tests/ps_static_analysis.js
+++ b/src/tests/ps_static_analysis.js
@@ -695,13 +695,28 @@ function deriveCountLayerInvariantFacts(psTagged) {
 
 function rulesInSection(psTagged, sectionName) {
     const section = psTagged.rule_sections.find(item => item.name === sectionName);
-    return section ? section.groups.flatMap(group => group.rules.map(rule => ({ group, rule }))) : [];
+    return section ? section.groups.flatMap(group => group.rules.map(rule => ({ section, group, rule }))) : [];
 }
 
-function earlySettersForObject(psTagged, objectName) {
-    return rulesInSection(psTagged, 'early')
-        .filter(entry => entry.rule.tags.solver_state_active)
-        .filter(entry => entry.rule.summary.rhs_terms.some(term => term.kind === 'present' && termMentionsObject(term, objectName)));
+function ruleHasPositiveLhsObject(rule, objectName) {
+    return rule.summary.lhs_terms.some(term => term.kind === 'present' && termMentionsObject(term, objectName));
+}
+
+function rulePresentsObjectOnRhs(rule, objectName) {
+    return rule.summary.rhs_terms.some(term =>
+        (term.kind === 'present' || term.kind === 'random_object') && termMentionsObject(term, objectName)
+    );
+}
+
+function ruleCreatesObject(rule, objectName) {
+    return rule.tags.solver_state_active
+        && rule.tags.object_mutating
+        && rulePresentsObjectOnRhs(rule, objectName)
+        && !ruleHasPositiveLhsObject(rule, objectName);
+}
+
+function creatorsForObject(psTagged, objectName) {
+    return allRuleEntries(psTagged).filter(entry => ruleCreatesObject(entry.rule, objectName));
 }
 
 function lateClearersForObject(psTagged, objectName) {
@@ -720,6 +735,16 @@ function ruleUnconditionallyClearsObject(rule, objectName) {
     return !rule.summary.rhs_terms.some(term => term.kind === 'present' && termMentionsObject(term, objectName));
 }
 
+function ruleEntryBefore(left, right) {
+    if (left.section.name === 'early' && right.section.name === 'late') return true;
+    if (left.section.name === right.section.name) return left.group.group_index < right.group.group_index;
+    return false;
+}
+
+function allCreatorsHaveLaterClearer(creators, clearers) {
+    return creators.every(creator => clearers.some(clearer => ruleEntryBefore(creator, clearer)));
+}
+
 function objectInWincondition(psTagged, objectName) {
     return psTagged.winconditions.some(win => win.subjects.includes(objectName) || win.targets.includes(objectName));
 }
@@ -727,22 +752,25 @@ function objectInWincondition(psTagged, objectName) {
 function deriveTransientBoundaryFacts(psTagged) {
     const results = [];
     for (const object of psTagged.objects) {
-        const setters = earlySettersForObject(psTagged, object.name);
+        const creators = creatorsForObject(psTagged, object.name);
         const clearers = lateClearersForObject(psTagged, object.name);
         const blockers = [];
-        if (setters.length === 0) blockers.push('not_created_in_early_rules');
+        if (creators.length === 0) blockers.push('not_created_before_end_cleanup');
         if (clearers.length === 0) blockers.push('no_late_cleanup_clear');
+        if (creators.length > 0 && clearers.length > 0 && !allCreatorsHaveLaterClearer(creators, clearers)) {
+            blockers.push('creator_not_followed_by_late_cleanup');
+        }
         if (!object.tags.present_in_no_levels) blockers.push('present_in_some_initial_levels');
         if (objectInWincondition(psTagged, object.name)) blockers.push('appears_in_wincondition');
-        if (setters.some(entry => entry.group.tags.has_again || entry.rule.tags.has_again)) blockers.push('has_again_taint');
-        if (setters.some(entry => entry.rule.rigid) || clearers.some(entry => entry.rule.rigid)) blockers.push('rigid_rule');
+        if (creators.some(entry => entry.group.tags.has_again || entry.rule.tags.has_again)) blockers.push('has_again_taint');
+        if (creators.some(entry => entry.rule.rigid) || clearers.some(entry => entry.rule.rigid)) blockers.push('rigid_rule');
         const status = blockers.length === 0 ? 'proved' : 'rejected';
         results.push(fact('transient_boundary', `object_${object.name}_end_turn_transient`, status, {
             subjects: { objects: [object.name] },
             tags: { single_turn_only: true },
-            proof: status === 'proved' ? ['created_in_early_rules', 'cleared_in_late_rules', 'absent_from_initial_levels_and_winconditions'] : [],
+            proof: status === 'proved' ? ['created_before_late_cleanup', 'cleared_in_late_rules', 'absent_from_initial_levels_and_winconditions'] : [],
             blockers,
-            evidence: setters.concat(clearers).map(entry => entry.rule.id),
+            evidence: creators.concat(clearers).map(entry => entry.rule.id),
         }));
     }
     return results;

--- a/src/tests/ps_static_analysis.js
+++ b/src/tests/ps_static_analysis.js
@@ -9,6 +9,7 @@ const { compileSemanticSource } = require('../canonicalize');
 const SCHEMA = 'ps-static-analysis-v1';
 const INERT_COMMANDS = new Set(['message', 'sfx0', 'sfx1', 'sfx2', 'sfx3', 'sfx4', 'sfx5', 'sfx6', 'sfx7', 'sfx8', 'sfx9', 'sfx10']);
 const SEMANTIC_COMMANDS = new Set(['cancel', 'again', 'restart', 'win', 'checkpoint']);
+const DIRECTIONAL_MOVEMENTS = new Set(['up', 'down', 'left', 'right', 'moving', 'randomdir']);
 
 function uniqueSorted(values) {
     return Array.from(new Set(values)).sort((left, right) =>
@@ -522,10 +523,78 @@ function deriveMergeabilityFacts(psTagged) {
     return results;
 }
 
+function layerForObject(psTagged, objectName) {
+    const object = psTagged.objects.find(item => item.name === objectName);
+    return object ? object.layer : null;
+}
+
+function playerLayers(psTagged) {
+    const player = psTagged.properties.find(item => item.canonical_name === 'player' || item.name.toLowerCase() === 'player');
+    if (!player) return [];
+    return uniqueSorted(player.members.map(objectName => String(layerForObject(psTagged, objectName))).filter(layer => layer !== 'null'));
+}
+
+function movementPairsFromTerms(psTagged, terms) {
+    const pairs = [];
+    for (const term of terms) {
+        if (term.kind !== 'present' || term.movement === null) continue;
+        for (const objectName of term.expanded_objects || []) {
+            const layer = layerForObject(psTagged, objectName);
+            if (layer !== null) pairs.push(`${layer}:${term.movement}`);
+        }
+    }
+    return pairs;
+}
+
+function ruleMovementRequirementsReachable(psTagged, rule, possibleMovements) {
+    const requirements = movementPairsFromTerms(psTagged, rule.summary.lhs_terms);
+    if (requirements.length === 0) return true;
+    return requirements.every(pair => possibleMovements.has(pair));
+}
+
+function deriveMovementActionFacts(psTagged) {
+    const activeRules = allRuleEntries(psTagged).map(entry => entry.rule).filter(rule => rule.tags.solver_state_active);
+    const possibleMovements = new Set(playerLayers(psTagged).map(layer => `${layer}:action`));
+    const blockers = [];
+    let changed = true;
+    while (changed) {
+        changed = false;
+        for (const rule of activeRules) {
+            if (!ruleMovementRequirementsReachable(psTagged, rule, possibleMovements)) continue;
+            if (rule.tags.reads_action) blockers.push('reads_action');
+            if (rule.tags.has_again) blockers.push('queues_again');
+            if (rule.rigid) blockers.push('rigid_rule');
+            if (rule.summary.lhs_movement.length === 0) blockers.push('autonomous_solver_active_rule');
+            if (rule.tags.object_mutating) blockers.push('action_may_mutate_objects');
+            for (const pair of movementPairsFromTerms(psTagged, rule.summary.rhs_terms)) {
+                const movement = pair.split(':')[1];
+                if (DIRECTIONAL_MOVEMENTS.has(movement)) blockers.push('action_may_create_directional_movement');
+                if (!possibleMovements.has(pair)) {
+                    possibleMovements.add(pair);
+                    changed = true;
+                }
+            }
+        }
+    }
+    const uniqueBlockers = uniqueSorted(blockers);
+    return [
+        fact('movement_action', 'movement_pairs', 'proved', {
+            value: Array.from(possibleMovements).sort(),
+            proof: ['conservative_movement_reachability_fixpoint'],
+        }),
+        fact('movement_action', 'action_noop', uniqueBlockers.length === 0 ? 'proved' : 'rejected', {
+            value: uniqueBlockers.length === 0,
+            blockers: uniqueBlockers,
+            proof: uniqueBlockers.length === 0 ? ['no_reachable_action_effects'] : [],
+            evidence: activeRules.map(rule => rule.id),
+        }),
+    ];
+}
+
 function deriveFacts(psTagged) {
     return {
         mergeability: deriveMergeabilityFacts(psTagged),
-        movement_action: [],
+        movement_action: deriveMovementActionFacts(psTagged),
         count_layer_invariants: [],
         transient_boundary: [],
     };

--- a/src/tests/ps_static_analysis.js
+++ b/src/tests/ps_static_analysis.js
@@ -17,6 +17,10 @@ function uniqueSorted(values) {
     );
 }
 
+function uniqueInOrder(values) {
+    return Array.from(new Set(values));
+}
+
 function displayName(state, name) {
     return (state.original_case_names && state.original_case_names[name]) || name;
 }
@@ -77,12 +81,15 @@ function buildProperties(state) {
 }
 
 function buildCollisionLayers(state) {
-    return Array.from(state.collisionLayers, (objects, id) => ({
-        id,
-        objects: Array.from(objects, name => displayName(state, name)),
-        canonical_objects: Array.from(objects),
-        tags: {},
-    }));
+    return Array.from(state.collisionLayers, (objects, id) => {
+        const canonicalObjects = uniqueInOrder(Array.from(objects));
+        return {
+            id,
+            objects: canonicalObjects.map(name => displayName(state, name)),
+            canonical_objects: canonicalObjects,
+            tags: {},
+        };
+    });
 }
 
 function buildWinconditions(state) {

--- a/src/tests/ps_static_analysis.js
+++ b/src/tests/ps_static_analysis.js
@@ -777,4 +777,5 @@ module.exports = {
     analyzeFile,
     analyzePaths,
     analyzeSource,
+    discoverInputFiles,
 };

--- a/src/tests/ps_static_analysis.js
+++ b/src/tests/ps_static_analysis.js
@@ -591,11 +591,50 @@ function deriveMovementActionFacts(psTagged) {
     ];
 }
 
+function termMentionsObject(term, objectName) {
+    return (term.expanded_objects || []).includes(objectName);
+}
+
+function ruleWritesObject(rule, objectName) {
+    if (!rule.tags.solver_state_active || !rule.tags.object_mutating) return false;
+    return rule.summary.rhs_terms.some(term => termMentionsObject(term, objectName));
+}
+
+function deriveCountLayerInvariantFacts(psTagged) {
+    const activeRules = allRuleEntries(psTagged).map(entry => entry.rule).filter(rule => rule.tags.solver_state_active);
+    const results = [];
+    for (const object of psTagged.objects) {
+        const writers = activeRules.filter(rule => ruleWritesObject(rule, object.name));
+        object.tags.may_be_created = writers.length > 0;
+        object.tags.may_be_destroyed = writers.length > 0;
+        object.tags.count_invariant = writers.length === 0;
+        results.push(fact('count_layer_invariants', `object_${object.name}_count_preserved`, writers.length === 0 ? 'proved' : 'rejected', {
+            subjects: { objects: [object.name] },
+            proof: writers.length === 0 ? ['no_solver_active_rule_writes_object'] : [],
+            blockers: writers.length === 0 ? [] : ['object_written_by_solver_active_rule'],
+            evidence: writers.map(rule => rule.id),
+        }));
+    }
+    for (const layer of psTagged.collision_layers) {
+        const layerWriterIds = uniqueSorted(layer.objects.flatMap(objectName =>
+            activeRules.filter(rule => ruleWritesObject(rule, objectName)).map(rule => rule.id)
+        ));
+        layer.tags.static = layerWriterIds.length === 0;
+        results.push(fact('count_layer_invariants', `layer_${layer.id}_static`, layerWriterIds.length === 0 ? 'proved' : 'candidate', {
+            subjects: { layers: [layer.id] },
+            proof: layerWriterIds.length === 0 ? ['no_solver_active_rule_writes_layer_objects'] : [],
+            blockers: layerWriterIds.length === 0 ? [] : ['layer_objects_may_change'],
+            evidence: layerWriterIds,
+        }));
+    }
+    return results;
+}
+
 function deriveFacts(psTagged) {
     return {
         mergeability: deriveMergeabilityFacts(psTagged),
         movement_action: deriveMovementActionFacts(psTagged),
-        count_layer_invariants: [],
+        count_layer_invariants: deriveCountLayerInvariantFacts(psTagged),
         transient_boundary: [],
     };
 }

--- a/src/tests/ps_static_analysis.js
+++ b/src/tests/ps_static_analysis.js
@@ -600,16 +600,29 @@ function termMentionsObject(term, objectName) {
     return (term.expanded_objects || []).includes(objectName);
 }
 
-function ruleWritesObject(rule, objectName) {
+function ruleMentionsObject(rule, objectName) {
+    return rule.summary.lhs_terms.concat(rule.summary.rhs_terms).some(term => termMentionsObject(term, objectName));
+}
+
+function ruleWritesCollisionLayerObject(psTagged, rule, objectName) {
+    const layer = layerForObject(psTagged, objectName);
+    if (layer === null) return false;
+    return rule.summary.rhs_terms.some(term =>
+        (term.kind === 'present' || term.kind === 'random_object')
+        && (term.expanded_objects || []).some(termObject => layerForObject(psTagged, termObject) === layer)
+    );
+}
+
+function ruleMayAffectObject(psTagged, rule, objectName) {
     if (!rule.tags.solver_state_active || !rule.tags.object_mutating) return false;
-    return rule.summary.rhs_terms.some(term => termMentionsObject(term, objectName));
+    return ruleMentionsObject(rule, objectName) || ruleWritesCollisionLayerObject(psTagged, rule, objectName);
 }
 
 function deriveCountLayerInvariantFacts(psTagged) {
     const activeRules = allRuleEntries(psTagged).map(entry => entry.rule).filter(rule => rule.tags.solver_state_active);
     const results = [];
     for (const object of psTagged.objects) {
-        const writers = activeRules.filter(rule => ruleWritesObject(rule, object.name));
+        const writers = activeRules.filter(rule => ruleMayAffectObject(psTagged, rule, object.name));
         object.tags.may_be_created = writers.length > 0;
         object.tags.may_be_destroyed = writers.length > 0;
         object.tags.count_invariant = writers.length === 0;
@@ -622,7 +635,7 @@ function deriveCountLayerInvariantFacts(psTagged) {
     }
     for (const layer of psTagged.collision_layers) {
         const layerWriterIds = uniqueSorted(layer.objects.flatMap(objectName =>
-            activeRules.filter(rule => ruleWritesObject(rule, objectName)).map(rule => rule.id)
+            activeRules.filter(rule => ruleMayAffectObject(psTagged, rule, objectName)).map(rule => rule.id)
         ));
         layer.tags.static = layerWriterIds.length === 0;
         results.push(fact('count_layer_invariants', `layer_${layer.id}_static`, layerWriterIds.length === 0 ? 'proved' : 'candidate', {
@@ -649,7 +662,17 @@ function earlySettersForObject(psTagged, objectName) {
 function lateClearersForObject(psTagged, objectName) {
     return rulesInSection(psTagged, 'late')
         .filter(entry => entry.rule.tags.solver_state_active)
-        .filter(entry => entry.rule.summary.rhs_terms.some(term => term.kind === 'absent' && termMentionsObject(term, objectName)));
+        .filter(entry => ruleUnconditionallyClearsObject(entry.rule, objectName));
+}
+
+function ruleUnconditionallyClearsObject(rule, objectName) {
+    const lhsTerms = rule.summary.lhs_terms;
+    if (lhsTerms.length !== 1) return false;
+    const lhsTerm = lhsTerms[0];
+    if (lhsTerm.kind !== 'present' || lhsTerm.movement !== null || !termMentionsObject(lhsTerm, objectName)) {
+        return false;
+    }
+    return !rule.summary.rhs_terms.some(term => term.kind === 'present' && termMentionsObject(term, objectName));
 }
 
 function objectInWincondition(psTagged, objectName) {
@@ -694,6 +717,18 @@ function filterFacts(facts, familyFilter) {
     return { [familyFilter]: facts[familyFilter] || [] };
 }
 
+function summarizeFacts(facts) {
+    const summary = { proved: 0, candidate: 0, rejected: 0 };
+    for (const familyFacts of Object.values(facts)) {
+        for (const item of familyFacts) {
+            if (Object.prototype.hasOwnProperty.call(summary, item.status)) {
+                summary[item.status]++;
+            }
+        }
+    }
+    return summary;
+}
+
 function analyzeSource(source, options = {}) {
     const sourcePath = options.sourcePath || '<memory>';
     let compiled;
@@ -727,13 +762,14 @@ function analyzeSource(source, options = {}) {
     }
 
     const psTagged = buildPsTagged(compiled.state, { sourcePath });
+    const facts = filterFacts(deriveFacts(psTagged), options.familyFilter);
     const report = {
         schema: SCHEMA,
         source: { path: sourcePath },
         status: 'ok',
         ps_tagged: psTagged,
-        facts: filterFacts(deriveFacts(psTagged), options.familyFilter),
-        summary: { proved: 0, candidate: 0, rejected: 0 },
+        facts,
+        summary: summarizeFacts(facts),
     };
 
     if (options.includePsTagged === false) {

--- a/src/tests/ps_static_analysis.js
+++ b/src/tests/ps_static_analysis.js
@@ -10,6 +10,7 @@ const SCHEMA = 'ps-static-analysis-v1';
 const INERT_COMMANDS = new Set(['message', 'sfx0', 'sfx1', 'sfx2', 'sfx3', 'sfx4', 'sfx5', 'sfx6', 'sfx7', 'sfx8', 'sfx9', 'sfx10']);
 const SEMANTIC_COMMANDS = new Set(['cancel', 'again', 'restart', 'win', 'checkpoint']);
 const DIRECTIONAL_MOVEMENTS = new Set(['up', 'down', 'left', 'right', 'moving', 'randomdir']);
+const CARDINAL_MOVEMENTS = ['up', 'down', 'left', 'right'];
 
 function uniqueSorted(values) {
     return Array.from(new Set(values)).sort((left, right) =>
@@ -211,6 +212,10 @@ function flattenTerms(side) {
     return side.flat(2);
 }
 
+function termHasInputMovementRequirement(term) {
+    return term.movement !== null && term.movement !== 'stationary';
+}
+
 function summarizeRule(rule) {
     const lhsTerms = flattenTerms(rule.lhs);
     const rhsTerms = flattenTerms(rule.rhs);
@@ -377,7 +382,9 @@ function tagGame(psTagged) {
     psTagged.game.tags.has_random = rules.some(rule => rule.random_rule || rule.summary.rhs_random_objects.length > 0);
     psTagged.game.tags.has_rigid = rules.some(rule => rule.rigid);
     psTagged.game.tags.has_action_rules = rules.some(rule => rule.tags.reads_action);
-    psTagged.game.tags.has_autonomous_tick_rules = rules.some(rule => rule.tags.solver_state_active && rule.summary.lhs_movement.length === 0);
+    psTagged.game.tags.has_autonomous_tick_rules = rules.some(rule =>
+        rule.tags.solver_state_active && !rule.summary.lhs_movement.some(termHasInputMovementRequirement)
+    );
 }
 
 function membersForRef(psTagged, ref) {
@@ -546,22 +553,53 @@ function playerLayers(psTagged) {
     return uniqueSorted(player.members.map(objectName => String(layerForObject(psTagged, objectName))).filter(layer => layer !== 'null'));
 }
 
-function movementPairsFromTerms(psTagged, terms) {
-    const pairs = [];
+function movementRequirementsFromTerms(psTagged, terms) {
+    const requirements = [];
     for (const term of terms) {
-        if (term.kind !== 'present' || term.movement === null) continue;
+        if (term.kind !== 'present' || !termHasInputMovementRequirement(term)) continue;
         for (const objectName of term.expanded_objects || []) {
             const layer = layerForObject(psTagged, objectName);
-            if (layer !== null) pairs.push(`${layer}:${term.movement}`);
+            if (layer !== null) requirements.push({ layer: String(layer), movement: term.movement });
+        }
+    }
+    return requirements;
+}
+
+function movementEffectsFromTerms(psTagged, terms) {
+    const pairs = [];
+    for (const term of terms) {
+        if (term.kind !== 'present' || term.movement === null || term.movement === 'stationary') continue;
+        for (const objectName of term.expanded_objects || []) {
+            const layer = layerForObject(psTagged, objectName);
+            if (layer === null) continue;
+            const layerName = String(layer);
+            if (term.movement === 'randomdir') {
+                for (const movement of CARDINAL_MOVEMENTS) pairs.push(`${layerName}:${movement}`);
+                pairs.push(`${layerName}:moving`);
+            } else if (CARDINAL_MOVEMENTS.includes(term.movement)) {
+                pairs.push(`${layerName}:${term.movement}`);
+                pairs.push(`${layerName}:moving`);
+            } else {
+                pairs.push(`${layerName}:${term.movement}`);
+            }
         }
     }
     return pairs;
 }
 
+function movementRequirementReachable(requirement, possibleMovements) {
+    if (requirement.movement === 'moving' || requirement.movement === 'randomdir' || requirement.movement === 'orthogonal') {
+        return CARDINAL_MOVEMENTS.some(movement => possibleMovements.has(`${requirement.layer}:${movement}`))
+            || possibleMovements.has(`${requirement.layer}:moving`)
+            || possibleMovements.has(`${requirement.layer}:randomdir`);
+    }
+    return possibleMovements.has(`${requirement.layer}:${requirement.movement}`);
+}
+
 function ruleMovementRequirementsReachable(psTagged, rule, possibleMovements) {
-    const requirements = movementPairsFromTerms(psTagged, rule.summary.lhs_terms);
+    const requirements = movementRequirementsFromTerms(psTagged, rule.summary.lhs_terms);
     if (requirements.length === 0) return true;
-    return requirements.every(pair => possibleMovements.has(pair));
+    return requirements.every(requirement => movementRequirementReachable(requirement, possibleMovements));
 }
 
 function deriveMovementActionFacts(psTagged) {
@@ -576,9 +614,9 @@ function deriveMovementActionFacts(psTagged) {
             if (rule.tags.reads_action) blockers.push('reads_action');
             if (rule.tags.has_again) blockers.push('queues_again');
             if (rule.rigid) blockers.push('rigid_rule');
-            if (rule.summary.lhs_movement.length === 0) blockers.push('autonomous_solver_active_rule');
+            if (!rule.summary.lhs_movement.some(termHasInputMovementRequirement)) blockers.push('autonomous_solver_active_rule');
             if (rule.tags.object_mutating) blockers.push('action_may_mutate_objects');
-            for (const pair of movementPairsFromTerms(psTagged, rule.summary.rhs_terms)) {
+            for (const pair of movementEffectsFromTerms(psTagged, rule.summary.rhs_terms)) {
                 const movement = pair.split(':')[1];
                 if (DIRECTIONAL_MOVEMENTS.has(movement)) blockers.push('action_may_create_directional_movement');
                 if (!possibleMovements.has(pair)) {

--- a/src/tests/ps_static_analysis.js
+++ b/src/tests/ps_static_analysis.js
@@ -8,6 +8,144 @@ const { compileSemanticSource } = require('../canonicalize');
 
 const SCHEMA = 'ps-static-analysis-v1';
 
+function uniqueSorted(values) {
+    return Array.from(new Set(values)).sort((left, right) =>
+        left.localeCompare(right, undefined, { numeric: true })
+    );
+}
+
+function displayName(state, name) {
+    return (state.original_case_names && state.original_case_names[name]) || name;
+}
+
+function objectInternalNamesFromMask(state, mask) {
+    const bitMask = Array.isArray(mask) ? mask[1] : mask;
+    const names = [];
+    if (!bitMask || typeof bitMask.get !== 'function') {
+        return names;
+    }
+    for (const [name, object] of Object.entries(state.objects)) {
+        if (bitMask.get(object.id)) {
+            names.push(name);
+        }
+    }
+    return uniqueSorted(names);
+}
+
+function objectNamesFromMask(state, mask) {
+    return objectInternalNamesFromMask(state, mask).map(name => displayName(state, name));
+}
+
+function buildObjects(state) {
+    return Object.keys(state.objects)
+        .map(name => ({
+            id: state.objects[name].id,
+            name: displayName(state, name),
+            canonical_name: name,
+            layer: state.objects[name].layer,
+            tags: {},
+        }))
+        .sort((left, right) => left.id - right.id);
+}
+
+function buildProperties(state) {
+    const properties = [];
+    for (const [name, members] of Object.entries(state.propertiesDict || {})) {
+        properties.push({
+            name: displayName(state, name),
+            canonical_name: name,
+            kind: 'property',
+            members: uniqueSorted(Array.from(members, member => displayName(state, member))),
+            tags: {},
+        });
+    }
+    for (const [name, target] of Object.entries(state.synonymsDict || {})) {
+        properties.push({
+            name: displayName(state, name),
+            canonical_name: name,
+            kind: 'synonym',
+            members: [displayName(state, target)],
+            tags: {},
+        });
+    }
+    return properties.sort((left, right) =>
+        left.name.localeCompare(right.name, undefined, { numeric: true })
+    );
+}
+
+function buildCollisionLayers(state) {
+    return Array.from(state.collisionLayers, (objects, id) => ({
+        id,
+        objects: Array.from(objects, name => displayName(state, name)),
+        canonical_objects: Array.from(objects),
+        tags: {},
+    }));
+}
+
+function buildWinconditions(state) {
+    return Array.from(state.winconditions, (condition, index) => ({
+        id: `win_${index}`,
+        quantifier: condition[0],
+        subjects: objectNamesFromMask(state, condition[1]),
+        targets: condition[2] ? objectNamesFromMask(state, condition[2]) : [],
+        tags: {},
+    }));
+}
+
+function buildLevels(state) {
+    return Array.from(state.levels, (level, index) => {
+        if (level.message !== undefined) {
+            return { index, kind: 'message', objects_present: [], layers_present: [], tags: {} };
+        }
+        const objects = new Set();
+        const layers = new Set();
+        for (let cellIndex = 0; cellIndex < level.n_tiles; cellIndex++) {
+            const cell = level.getCell(cellIndex);
+            for (const name of objectInternalNamesFromMask(state, cell)) {
+                objects.add(displayName(state, name));
+                layers.add(state.objects[name].layer);
+            }
+        }
+        return {
+            index,
+            kind: 'level',
+            width: level.width,
+            height: level.height,
+            objects_present: uniqueSorted(Array.from(objects)),
+            layers_present: Array.from(layers).sort((left, right) => left - right),
+            tags: {},
+        };
+    });
+}
+
+function tagObjectLevelPresence(psTagged) {
+    const playableLevels = psTagged.levels.filter(level => level.kind === 'level');
+    for (const object of psTagged.objects) {
+        const presentCount = playableLevels.filter(level => level.objects_present.includes(object.name)).length;
+        object.tags.present_in_all_levels = playableLevels.length > 0 && presentCount === playableLevels.length;
+        object.tags.present_in_some_levels = presentCount > 0 && presentCount < playableLevels.length;
+        object.tags.present_in_no_levels = presentCount === 0;
+    }
+}
+
+function buildPsTagged(state, options = {}) {
+    const psTagged = {
+        game: {
+            title: state.metadata && state.metadata.title,
+            source_path: options.sourcePath || '<memory>',
+            tags: {},
+        },
+        objects: buildObjects(state),
+        properties: buildProperties(state),
+        collision_layers: buildCollisionLayers(state),
+        winconditions: buildWinconditions(state),
+        levels: buildLevels(state),
+        rule_sections: [],
+    };
+    tagObjectLevelPresence(psTagged);
+    return psTagged;
+}
+
 function emptyFacts() {
     return {
         mergeability: [],
@@ -36,7 +174,7 @@ function analyzeSource(source, options = {}) {
         };
     }
 
-    const psTagged = { game: { tags: {} } };
+    const psTagged = buildPsTagged(compiled.state, { sourcePath });
     const report = {
         schema: SCHEMA,
         source: { path: sourcePath },

--- a/src/tests/ps_static_analysis.js
+++ b/src/tests/ps_static_analysis.js
@@ -1,0 +1,65 @@
+#!/usr/bin/env node
+'use strict';
+
+const fs = require('fs');
+const path = require('path');
+
+const { compileSemanticSource } = require('../canonicalize');
+
+const SCHEMA = 'ps-static-analysis-v1';
+
+function emptyFacts() {
+    return {
+        mergeability: [],
+        movement_action: [],
+        count_layer_invariants: [],
+        transient_boundary: [],
+    };
+}
+
+function analyzeSource(source, options = {}) {
+    const sourcePath = options.sourcePath || '<memory>';
+    const compiled = compileSemanticSource(source, {
+        includeWinConditions: true,
+        throwOnError: false,
+    });
+
+    if (compiled.errorCount > 0 || compiled.state === null || compiled.state.invalid) {
+        return {
+            schema: SCHEMA,
+            source: { path: sourcePath },
+            status: 'compile_error',
+            errors: compiled.errorStrings.slice(),
+            ps_tagged: null,
+            facts: emptyFacts(),
+            summary: { proved: 0, candidate: 0, rejected: 0 },
+        };
+    }
+
+    const psTagged = { game: { tags: {} } };
+    const report = {
+        schema: SCHEMA,
+        source: { path: sourcePath },
+        status: 'ok',
+        ps_tagged: psTagged,
+        facts: emptyFacts(),
+        summary: { proved: 0, candidate: 0, rejected: 0 },
+    };
+
+    if (options.includePsTagged === false) {
+        delete report.ps_tagged;
+    }
+    return report;
+}
+
+function analyzeFile(filePath, options = {}) {
+    const resolved = path.resolve(filePath);
+    const source = fs.readFileSync(resolved, 'utf8');
+    return analyzeSource(source, Object.assign({}, options, { sourcePath: filePath }));
+}
+
+module.exports = {
+    SCHEMA,
+    analyzeFile,
+    analyzeSource,
+};

--- a/src/tests/ps_static_analysis.js
+++ b/src/tests/ps_static_analysis.js
@@ -7,6 +7,8 @@ const path = require('path');
 const { compileSemanticSource } = require('../canonicalize');
 
 const SCHEMA = 'ps-static-analysis-v1';
+const INERT_COMMANDS = new Set(['message', 'sfx0', 'sfx1', 'sfx2', 'sfx3', 'sfx4', 'sfx5', 'sfx6', 'sfx7', 'sfx8', 'sfx9', 'sfx10']);
+const SEMANTIC_COMMANDS = new Set(['cancel', 'again', 'restart', 'win', 'checkpoint']);
 
 function uniqueSorted(values) {
     return Array.from(new Set(values)).sort((left, right) =>
@@ -128,6 +130,243 @@ function tagObjectLevelPresence(psTagged) {
     }
 }
 
+function directionName(direction) {
+    if (typeof direction === 'string') return direction;
+    if (direction === 1) return 'up';
+    if (direction === 2) return 'down';
+    if (direction === 4) return 'left';
+    if (direction === 8) return 'right';
+    if (direction === 15) return 'orthogonal';
+    if (direction === 16) return 'action';
+    return String(direction);
+}
+
+function refForName(state, name) {
+    if (state.objects[name]) {
+        return { type: 'object', name: displayName(state, name), canonical_name: name };
+    }
+    if (state.propertiesDict && state.propertiesDict[name]) {
+        return {
+            type: 'property',
+            name: displayName(state, name),
+            canonical_name: name,
+            members: uniqueSorted(Array.from(state.propertiesDict[name], member => displayName(state, member))),
+        };
+    }
+    if (state.synonymsDict && state.synonymsDict[name]) {
+        return {
+            type: 'synonym',
+            name: displayName(state, name),
+            canonical_name: name,
+            members: [displayName(state, state.synonymsDict[name])],
+        };
+    }
+    return { type: 'unknown', name };
+}
+
+function termFromPair(state, direction, name) {
+    if (direction === '...' && name === '...') {
+        return { kind: 'present', ref: { type: 'ellipsis' }, movement: null };
+    }
+    if (direction === 'no') {
+        return { kind: 'absent', ref: refForName(state, name), movement: null };
+    }
+    if (direction === 'random') {
+        return { kind: 'random_object', ref: refForName(state, name), movement: null };
+    }
+    if (direction === '') {
+        return { kind: 'present', ref: refForName(state, name), movement: null };
+    }
+    return { kind: 'present', ref: refForName(state, name), movement: directionName(direction) };
+}
+
+function termsFromCell(state, cell) {
+    const terms = [];
+    for (let index = 0; index < cell.length; index += 2) {
+        terms.push(termFromPair(state, cell[index], cell[index + 1]));
+    }
+    return terms;
+}
+
+function termsFromSide(state, side) {
+    return Array.from(side || [], row =>
+        Array.from(row, cell => termsFromCell(state, cell))
+    );
+}
+
+function flattenTerms(side) {
+    return side.flat(2);
+}
+
+function summarizeRule(rule) {
+    const lhsTerms = flattenTerms(rule.lhs);
+    const rhsTerms = flattenTerms(rule.rhs);
+    return {
+        lhs_terms: lhsTerms,
+        rhs_terms: rhsTerms,
+        lhs_present: lhsTerms.filter(term => term.kind === 'present'),
+        lhs_absent: lhsTerms.filter(term => term.kind === 'absent'),
+        lhs_movement: lhsTerms.filter(term => term.movement !== null),
+        rhs_present: rhsTerms.filter(term => term.kind === 'present'),
+        rhs_absent: rhsTerms.filter(term => term.kind === 'absent'),
+        rhs_random_objects: rhsTerms.filter(term => term.kind === 'random_object'),
+        rhs_movement: rhsTerms.filter(term => term.movement !== null),
+        semantic_commands: rule.commands.map(command => command[0]).filter(command => SEMANTIC_COMMANDS.has(command)),
+        inert_commands: rule.commands.map(command => command[0]).filter(command => INERT_COMMANDS.has(command)),
+    };
+}
+
+function objectTermSignature(terms) {
+    return JSON.stringify(terms
+        .filter(term => term.kind === 'present')
+        .map(term => JSON.stringify(term.ref))
+        .sort());
+}
+
+function movementTermSignature(terms) {
+    return JSON.stringify(terms
+        .filter(term => term.kind === 'present' && term.movement !== null)
+        .map(term => `${JSON.stringify(term.ref)}:${term.movement}`)
+        .sort());
+}
+
+function tagRule(rule) {
+    rule.summary = summarizeRule(rule);
+    const commandNames = rule.commands.map(command => command[0]);
+    const hasOnlyInertCommands = commandNames.length > 0
+        && commandNames.every(command => INERT_COMMANDS.has(command));
+    const hasReplacement = rule.rhs.length > 0;
+    const objectMutating = hasReplacement
+        && (objectTermSignature(rule.summary.lhs_terms) !== objectTermSignature(rule.summary.rhs_terms)
+        || rule.summary.rhs_absent.length > 0
+        || rule.summary.rhs_random_objects.length > 0);
+    const writesMovement = hasReplacement
+        && (rule.summary.rhs_movement.length > 0
+        || movementTermSignature(rule.summary.lhs_terms) !== movementTermSignature(rule.summary.rhs_terms));
+    const hasSemanticCommand = rule.summary.semantic_commands.length > 0;
+
+    rule.tags.command_only = commandNames.length > 0 && !objectMutating && !writesMovement;
+    rule.tags.inert_command_only = hasOnlyInertCommands && rule.tags.command_only;
+    rule.tags.object_mutating = objectMutating;
+    rule.tags.writes_movement = writesMovement;
+    rule.tags.movement_only = writesMovement && !objectMutating && !hasSemanticCommand;
+    rule.tags.reads_action = rule.summary.lhs_movement.some(term => term.movement === 'action');
+    rule.tags.has_again = rule.summary.semantic_commands.includes('again');
+    const hasNonInertEffect = objectMutating || writesMovement || hasSemanticCommand;
+    rule.tags.solver_state_active = !rule.tags.inert_command_only && hasNonInertEffect;
+    if (rule.rigid && hasNonInertEffect) {
+        rule.tags.rigid_active = true;
+    }
+}
+
+function buildRuleSections(state) {
+    const rules = Array.from(state.rules || []);
+    return [
+        buildRuleSection(state, 'early', rules.filter(rule => !rule.late)),
+        buildRuleSection(state, 'late', rules.filter(rule => rule.late)),
+    ];
+}
+
+function buildRuleSection(state, name, rules) {
+    const groupNumbers = [];
+    const groupMap = new Map();
+    for (const rule of rules) {
+        if (!groupMap.has(rule.groupNumber)) {
+            groupMap.set(rule.groupNumber, []);
+            groupNumbers.push(rule.groupNumber);
+        }
+        groupMap.get(rule.groupNumber).push(rule);
+    }
+    const groups = groupNumbers.map((groupNumber, index) =>
+        buildRuleGroup(state, name, index, groupNumber, groupMap.get(groupNumber))
+    );
+    return {
+        name,
+        loops: buildLoopSummaries(state, groups),
+        groups,
+    };
+}
+
+function buildLoopSummaries(state, groups) {
+    const loops = [];
+    const stack = [];
+    for (const loop of Array.from(state.loops || [])) {
+        const line = loop[0];
+        const bracket = loop[1];
+        if (bracket === 1) {
+            stack.push({ id: `loop_${loops.length}`, start_line: line, end_line: null });
+        } else if (bracket === -1 && stack.length > 0) {
+            const active = stack.pop();
+            active.end_line = line;
+            active.group_ids = groups
+                .filter(group => group.source_line_min > active.start_line && group.source_line_max < active.end_line)
+                .map(group => group.id);
+            loops.push(active);
+        }
+    }
+    return loops;
+}
+
+function buildRuleGroup(state, sectionName, groupIndex, groupNumber, sourceRules) {
+    const rules = sourceRules.map((rule, ruleIndex) => buildRuleIr(state, sectionName, groupIndex, rule, ruleIndex));
+    const group = {
+        id: `${sectionName}_group_${groupIndex}`,
+        group_index: groupIndex,
+        group_number: groupNumber,
+        source_line_min: Math.min(...sourceRules.map(rule => rule.lineNumber)),
+        source_line_max: Math.max(...sourceRules.map(rule => rule.lineNumber)),
+        random: sourceRules.some(rule => rule.randomRule),
+        tags: {},
+        rules,
+    };
+    for (const rule of rules) {
+        tagRule(rule);
+    }
+    tagGroup(group);
+    return group;
+}
+
+function buildRuleIr(state, sectionName, groupIndex, rule, ruleIndex) {
+    return {
+        id: `${sectionName}_group_${groupIndex}_rule_${ruleIndex}`,
+        source_line: rule.lineNumber,
+        direction: directionName(rule.direction),
+        late: !!rule.late || sectionName === 'late',
+        rigid: !!rule.rigid,
+        random_rule: !!rule.randomRule,
+        tags: {},
+        commands: Array.from(rule.commands || [], command => Array.from(command)),
+        lhs: termsFromSide(state, rule.lhs),
+        rhs: termsFromSide(state, rule.rhs),
+        summary: {},
+    };
+}
+
+function tagGroup(group) {
+    group.tags.has_again = group.rules.some(rule => rule.tags.has_again);
+    group.tags.object_mutating = group.rules.some(rule => rule.tags.object_mutating);
+    group.tags.movement_only = group.rules.some(rule => rule.tags.movement_only) && !group.tags.object_mutating;
+    group.tags.command_only = group.rules.every(rule => rule.tags.command_only);
+    group.tags.solver_state_active = group.rules.some(rule => rule.tags.solver_state_active);
+}
+
+function allRuleEntries(psTagged) {
+    return psTagged.rule_sections.flatMap(section =>
+        section.groups.flatMap(group =>
+            group.rules.map(rule => ({ section, group, rule }))
+        )
+    );
+}
+
+function tagGame(psTagged) {
+    const rules = allRuleEntries(psTagged).map(entry => entry.rule);
+    psTagged.game.tags.has_again = rules.some(rule => rule.tags.has_again);
+    psTagged.game.tags.has_random = rules.some(rule => rule.random_rule || rule.summary.rhs_random_objects.length > 0);
+    psTagged.game.tags.has_rigid = rules.some(rule => rule.rigid);
+    psTagged.game.tags.has_action_rules = rules.some(rule => rule.tags.reads_action);
+    psTagged.game.tags.has_autonomous_tick_rules = rules.some(rule => rule.tags.solver_state_active && rule.summary.lhs_movement.length === 0);
+}
+
 function buildPsTagged(state, options = {}) {
     const psTagged = {
         game: {
@@ -140,9 +379,10 @@ function buildPsTagged(state, options = {}) {
         collision_layers: buildCollisionLayers(state),
         winconditions: buildWinconditions(state),
         levels: buildLevels(state),
-        rule_sections: [],
+        rule_sections: buildRuleSections(state),
     };
     tagObjectLevelPresence(psTagged);
+    tagGame(psTagged);
     return psTagged;
 }
 

--- a/src/tests/ps_static_analysis.js
+++ b/src/tests/ps_static_analysis.js
@@ -86,13 +86,18 @@ function buildCollisionLayers(state) {
 }
 
 function buildWinconditions(state) {
-    return Array.from(state.winconditions, (condition, index) => ({
-        id: `win_${index}`,
-        quantifier: condition[0],
-        subjects: objectNamesFromMask(state, condition[1]),
-        targets: condition[2] ? objectNamesFromMask(state, condition[2]) : [],
-        tags: {},
-    }));
+    const objectCount = Object.keys(state.objects).length;
+    return Array.from(state.winconditions, (condition, index) => {
+        const targetNames = condition[2] ? objectInternalNamesFromMask(state, condition[2]) : [];
+        const plainCondition = targetNames.length === objectCount;
+        return {
+            id: `win_${index}`,
+            quantifier: condition[0],
+            subjects: objectNamesFromMask(state, condition[1]),
+            targets: plainCondition ? [] : targetNames.map(name => displayName(state, name)),
+            tags: { plain: plainCondition },
+        };
+    });
 }
 
 function buildLevels(state) {
@@ -630,12 +635,57 @@ function deriveCountLayerInvariantFacts(psTagged) {
     return results;
 }
 
+function rulesInSection(psTagged, sectionName) {
+    const section = psTagged.rule_sections.find(item => item.name === sectionName);
+    return section ? section.groups.flatMap(group => group.rules.map(rule => ({ group, rule }))) : [];
+}
+
+function earlySettersForObject(psTagged, objectName) {
+    return rulesInSection(psTagged, 'early')
+        .filter(entry => entry.rule.tags.solver_state_active)
+        .filter(entry => entry.rule.summary.rhs_terms.some(term => term.kind === 'present' && termMentionsObject(term, objectName)));
+}
+
+function lateClearersForObject(psTagged, objectName) {
+    return rulesInSection(psTagged, 'late')
+        .filter(entry => entry.rule.tags.solver_state_active)
+        .filter(entry => entry.rule.summary.rhs_terms.some(term => term.kind === 'absent' && termMentionsObject(term, objectName)));
+}
+
+function objectInWincondition(psTagged, objectName) {
+    return psTagged.winconditions.some(win => win.subjects.includes(objectName) || win.targets.includes(objectName));
+}
+
+function deriveTransientBoundaryFacts(psTagged) {
+    const results = [];
+    for (const object of psTagged.objects) {
+        const setters = earlySettersForObject(psTagged, object.name);
+        const clearers = lateClearersForObject(psTagged, object.name);
+        const blockers = [];
+        if (setters.length === 0) blockers.push('not_created_in_early_rules');
+        if (clearers.length === 0) blockers.push('no_late_cleanup_clear');
+        if (!object.tags.present_in_no_levels) blockers.push('present_in_some_initial_levels');
+        if (objectInWincondition(psTagged, object.name)) blockers.push('appears_in_wincondition');
+        if (setters.some(entry => entry.group.tags.has_again || entry.rule.tags.has_again)) blockers.push('has_again_taint');
+        if (setters.some(entry => entry.rule.rigid) || clearers.some(entry => entry.rule.rigid)) blockers.push('rigid_rule');
+        const status = blockers.length === 0 ? 'proved' : 'rejected';
+        results.push(fact('transient_boundary', `object_${object.name}_end_turn_transient`, status, {
+            subjects: { objects: [object.name] },
+            tags: { single_turn_only: true },
+            proof: status === 'proved' ? ['created_in_early_rules', 'cleared_in_late_rules', 'absent_from_initial_levels_and_winconditions'] : [],
+            blockers,
+            evidence: setters.concat(clearers).map(entry => entry.rule.id),
+        }));
+    }
+    return results;
+}
+
 function deriveFacts(psTagged) {
     return {
         mergeability: deriveMergeabilityFacts(psTagged),
         movement_action: deriveMovementActionFacts(psTagged),
         count_layer_invariants: deriveCountLayerInvariantFacts(psTagged),
-        transient_boundary: [],
+        transient_boundary: deriveTransientBoundaryFacts(psTagged),
     };
 }
 

--- a/src/tests/ps_static_analysis.js
+++ b/src/tests/ps_static_analysis.js
@@ -696,10 +696,23 @@ function filterFacts(facts, familyFilter) {
 
 function analyzeSource(source, options = {}) {
     const sourcePath = options.sourcePath || '<memory>';
-    const compiled = compileSemanticSource(source, {
-        includeWinConditions: true,
-        throwOnError: false,
-    });
+    let compiled;
+    try {
+        compiled = compileSemanticSource(source, {
+            includeWinConditions: true,
+            throwOnError: false,
+        });
+    } catch (error) {
+        return {
+            schema: SCHEMA,
+            source: { path: sourcePath },
+            status: 'compile_error',
+            errors: [error && error.message ? error.message : String(error)],
+            ps_tagged: null,
+            facts: emptyFacts(),
+            summary: { proved: 0, candidate: 0, rejected: 0 },
+        };
+    }
 
     if (compiled.errorCount > 0 || compiled.state === null || compiled.state.invalid) {
         return {
@@ -735,8 +748,33 @@ function analyzeFile(filePath, options = {}) {
     return analyzeSource(source, Object.assign({}, options, { sourcePath: filePath }));
 }
 
+function discoverInputFiles(inputs) {
+    const files = [];
+    for (const input of inputs) {
+        const stat = fs.statSync(input);
+        if (stat.isDirectory()) {
+            for (const entry of fs.readdirSync(input).sort()) {
+                const fullPath = path.join(input, entry);
+                if (fs.statSync(fullPath).isFile() && fullPath.endsWith('.txt')) {
+                    files.push(fullPath);
+                }
+            }
+        } else {
+            files.push(input);
+        }
+    }
+    return files;
+}
+
+function analyzePaths(inputs, options = {}) {
+    return discoverInputFiles(inputs)
+        .filter(filePath => !options.gameFilter || filePath.toLowerCase().includes(options.gameFilter.toLowerCase()))
+        .map(filePath => analyzeFile(filePath, options));
+}
+
 module.exports = {
     SCHEMA,
     analyzeFile,
+    analyzePaths,
     analyzeSource,
 };

--- a/src/tests/ps_static_analysis.js
+++ b/src/tests/ps_static_analysis.js
@@ -367,6 +367,39 @@ function tagGame(psTagged) {
     psTagged.game.tags.has_autonomous_tick_rules = rules.some(rule => rule.tags.solver_state_active && rule.summary.lhs_movement.length === 0);
 }
 
+function membersForRef(psTagged, ref) {
+    if (ref.type === 'object') return [ref.name];
+    if (ref.type === 'object_set') return ref.objects.slice();
+    if (ref.type === 'property' || ref.type === 'synonym' || ref.type === 'unknown') {
+        const property = psTagged.properties.find(item => item.name === ref.name || item.canonical_name === ref.canonical_name);
+        return property ? property.members.slice() : [ref.name];
+    }
+    return [];
+}
+
+function refForObjectName(psTagged, objectName) {
+    const object = psTagged.objects.find(item => item.name === objectName);
+    if (!object) return { type: 'object', name: objectName };
+    return { type: 'object', name: object.name, canonical_name: object.canonical_name };
+}
+
+function normalizeTermRefs(psTagged) {
+    for (const { rule } of allRuleEntries(psTagged)) {
+        for (const term of rule.summary.lhs_terms.concat(rule.summary.rhs_terms)) {
+            const members = membersForRef(psTagged, term.ref);
+            if (members.length === 1 && psTagged.objects.some(object => object.name === members[0])) {
+                term.expanded_objects = members;
+                term.ref = refForObjectName(psTagged, members[0]);
+            } else if (members.length > 1) {
+                term.expanded_objects = uniqueSorted(members);
+                term.ref = { type: 'object_set', objects: uniqueSorted(members), source: term.ref.name || term.ref.type };
+            } else {
+                term.expanded_objects = [];
+            }
+        }
+    }
+}
+
 function buildPsTagged(state, options = {}) {
     const psTagged = {
         game: {
@@ -383,6 +416,7 @@ function buildPsTagged(state, options = {}) {
     };
     tagObjectLevelPresence(psTagged);
     tagGame(psTagged);
+    normalizeTermRefs(psTagged);
     return psTagged;
 }
 
@@ -393,6 +427,113 @@ function emptyFacts() {
         count_layer_invariants: [],
         transient_boundary: [],
     };
+}
+
+function fact(family, id, status, fields) {
+    return Object.assign({
+        family,
+        id,
+        status,
+        subjects: {},
+        tags: {},
+        proof: [],
+        blockers: [],
+        evidence: [],
+    }, fields);
+}
+
+function sameArray(left, right) {
+    return JSON.stringify(left) === JSON.stringify(right);
+}
+
+function winRoleForObject(psTagged, objectName) {
+    return psTagged.winconditions.map(win => ({
+        id: win.id,
+        in_subjects: win.subjects.includes(objectName),
+        in_targets: win.targets.includes(objectName),
+    }));
+}
+
+function directObservationsForObjects(psTagged, objects) {
+    const observations = [];
+    for (const { rule } of allRuleEntries(psTagged)) {
+        if (rule.tags.inert_command_only) continue;
+        for (const row of rule.lhs) {
+            for (const cell of row) {
+                const directTerms = cell.filter(term =>
+                    term.ref.type === 'object' && objects.includes(term.ref.name)
+                );
+                if (directTerms.length === 0) continue;
+                const observedObjects = uniqueSorted(directTerms.map(term => term.ref.name));
+                const sameObservation = new Set(directTerms.map(term => `${term.kind}:${term.movement}`)).size === 1;
+                if (sameArray(observedObjects, objects) && sameObservation) continue;
+                observations.push(...directTerms.map(term => ({
+                    rule_id: rule.id,
+                    source_line: rule.source_line,
+                    kind: term.kind,
+                    movement: term.movement,
+                    object: term.ref.name,
+                })));
+            }
+        }
+    }
+    return observations;
+}
+
+function groupObservationIsShared(psTagged, objects) {
+    for (const { rule } of allRuleEntries(psTagged)) {
+        if (rule.tags.inert_command_only) continue;
+        for (const term of rule.summary.lhs_terms) {
+            if (term.ref.type !== 'object_set') continue;
+            const overlap = objects.filter(objectName => term.expanded_objects.includes(objectName));
+            if (overlap.length > 0 && overlap.length !== objects.length) {
+                return false;
+            }
+        }
+    }
+    return true;
+}
+
+function deriveMergeabilityFacts(psTagged) {
+    const results = [];
+    for (const layer of psTagged.collision_layers) {
+        if (layer.objects.length < 2) continue;
+        for (let left = 0; left < layer.objects.length; left++) {
+            for (let right = left + 1; right < layer.objects.length; right++) {
+                const objects = [layer.objects[left], layer.objects[right]].sort();
+                const blockers = [];
+                const directObservations = directObservationsForObjects(psTagged, objects);
+                if (directObservations.length > 0) blockers.push('individual_lhs_read');
+                if (!sameArray(winRoleForObject(psTagged, objects[0]), winRoleForObject(psTagged, objects[1]))) {
+                    blockers.push('different_win_roles');
+                }
+                if (!groupObservationIsShared(psTagged, objects)) {
+                    blockers.push('partial_property_observation');
+                }
+                results.push(fact('mergeability', `merge_${objects.join('_')}`, blockers.length === 0 ? 'candidate' : 'rejected', {
+                    subjects: { objects },
+                    proof: blockers.length === 0 ? ['same_collision_layer', 'observed_only_through_shared_sets', 'same_win_roles'] : ['same_collision_layer'],
+                    blockers,
+                    evidence: directObservations.map(item => item.rule_id).concat(`layer_${layer.id}`),
+                }));
+            }
+        }
+    }
+    return results;
+}
+
+function deriveFacts(psTagged) {
+    return {
+        mergeability: deriveMergeabilityFacts(psTagged),
+        movement_action: [],
+        count_layer_invariants: [],
+        transient_boundary: [],
+    };
+}
+
+function filterFacts(facts, familyFilter) {
+    if (!familyFilter) return facts;
+    return { [familyFilter]: facts[familyFilter] || [] };
 }
 
 function analyzeSource(source, options = {}) {
@@ -420,7 +561,7 @@ function analyzeSource(source, options = {}) {
         source: { path: sourcePath },
         status: 'ok',
         ps_tagged: psTagged,
-        facts: emptyFacts(),
+        facts: filterFacts(deriveFacts(psTagged), options.familyFilter),
         summary: { proved: 0, candidate: 0, rejected: 0 },
     };
 

--- a/src/tests/ps_static_analysis_node.js
+++ b/src/tests/ps_static_analysis_node.js
@@ -326,6 +326,14 @@ const actionMovementFact = actionMovement.facts.movement_action.find(item => ite
 assert.strictEqual(actionMovementFact.status, 'rejected');
 assert.ok(actionMovementFact.blockers.includes('action_may_create_directional_movement'));
 
+const STATIONARY_TICK_GAME = SIMPLE_GAME.replace('[ > Hero ] -> [ > Hero ]', '[ stationary Goal ] -> [ randomDir Goal ]');
+const stationaryTick = analyzeSource(STATIONARY_TICK_GAME, { sourcePath: 'stationary_tick.txt' });
+const stationaryTickFact = stationaryTick.facts.movement_action.find(item => item.id === 'action_noop');
+assert.strictEqual(stationaryTick.ps_tagged.game.tags.has_autonomous_tick_rules, true);
+assert.strictEqual(stationaryTickFact.status, 'rejected');
+assert.ok(stationaryTickFact.blockers.includes('autonomous_solver_active_rule'));
+assert.ok(stationaryTickFact.blockers.includes('action_may_create_directional_movement'));
+
 const countFacts = report.facts.count_layer_invariants;
 assert.ok(countFacts.some(item => item.id === 'object_Hero_count_preserved'), 'Hero count fact should exist');
 assert.ok(countFacts.some(item => item.id === 'layer_0_static'), 'Background layer static fact should exist');

--- a/src/tests/ps_static_analysis_node.js
+++ b/src/tests/ps_static_analysis_node.js
@@ -66,6 +66,7 @@ const report = analyzeSource(SIMPLE_GAME, { sourcePath: 'simple.txt' });
 assert.strictEqual(report.schema, 'ps-static-analysis-v1');
 assert.strictEqual(report.status, 'ok');
 assert.strictEqual(report.source.path, 'simple.txt');
+assert.ok(report.summary.proved > 0, 'summary should count proved facts');
 assert.ok(report.ps_tagged, 'report should include ps_tagged by default');
 assert.ok(report.facts.mergeability, 'report should include mergeability facts');
 assert.ok(report.facts.movement_action, 'report should include movement_action facts');
@@ -323,6 +324,16 @@ const goalCount = spawnReport.facts.count_layer_invariants.find(item => item.id 
 assert.strictEqual(goalCount.status, 'rejected');
 assert.ok(goalCount.blockers.includes('object_written_by_solver_active_rule'));
 
+const DESTROY_GAME = SIMPLE_GAME.replace('[ > Hero ] -> [ > Hero ]', '[ Hero ] -> []');
+const destroyReport = analyzeSource(DESTROY_GAME, { sourcePath: 'destroy.txt' });
+const heroDestroyCount = destroyReport.facts.count_layer_invariants.find(item => item.id === 'object_Hero_count_preserved');
+assert.strictEqual(heroDestroyCount.status, 'rejected', 'deleting an object to an empty RHS should reject count preservation');
+
+const LAYER_OVERWRITE_GAME = SIMPLE_GAME.replace('[ > Hero ] -> [ > Hero ]', '[ no Goal ] -> [ Goal ]');
+const layerOverwriteReport = analyzeSource(LAYER_OVERWRITE_GAME, { sourcePath: 'layer_overwrite.txt' });
+const heroOverwriteCount = layerOverwriteReport.facts.count_layer_invariants.find(item => item.id === 'object_Hero_count_preserved');
+assert.strictEqual(heroOverwriteCount.status, 'rejected', 'writing one object in a collision layer can remove siblings');
+
 const TRANSIENT_GAME = `
 title Transient
 ========
@@ -368,6 +379,11 @@ const transient = analyzeSource(TRANSIENT_GAME, { sourcePath: 'transient.txt' })
 const markTransient = transient.facts.transient_boundary.find(item => item.id === 'object_Mark_end_turn_transient');
 assert.strictEqual(markTransient.status, 'proved');
 assert.strictEqual(markTransient.tags.single_turn_only, true);
+
+const EMPTY_CLEAR_TRANSIENT_GAME = TRANSIENT_GAME.replace('late [ Mark ] -> [ no Mark ]', 'late [ Mark ] -> []');
+const emptyClearTransient = analyzeSource(EMPTY_CLEAR_TRANSIENT_GAME, { sourcePath: 'empty_clear_transient.txt' });
+const emptyClearMark = emptyClearTransient.facts.transient_boundary.find(item => item.id === 'object_Mark_end_turn_transient');
+assert.strictEqual(emptyClearMark.status, 'proved', 'empty RHS cleanup should count as an end-turn clear');
 
 const AGAIN_TAINT_GAME = TRANSIENT_GAME.replace('[ Player ] -> [ Player Mark ]', '[ Player ] -> [ Player Mark ] again');
 const againTaint = analyzeSource(AGAIN_TAINT_GAME, { sourcePath: 'again_taint.txt' });

--- a/src/tests/ps_static_analysis_node.js
+++ b/src/tests/ps_static_analysis_node.js
@@ -375,4 +375,25 @@ const againMark = againTaint.facts.transient_boundary.find(item => item.id === '
 assert.strictEqual(againMark.status, 'rejected');
 assert.ok(againMark.blockers.includes('has_again_taint'));
 
+const noTagged = analyzeSource(SIMPLE_GAME, { sourcePath: 'simple.txt', includePsTagged: false });
+assert.strictEqual(noTagged.ps_tagged, undefined, 'includePsTagged=false should remove ps_tagged');
+
+const onlyMerge = analyzeSource(SIMPLE_GAME, { sourcePath: 'simple.txt', familyFilter: 'mergeability' });
+assert.deepStrictEqual(Object.keys(onlyMerge.facts), ['mergeability'], 'familyFilter should keep one family');
+
+function assertProvedFactsHaveProof(reportToCheck) {
+    for (const familyFacts of Object.values(reportToCheck.facts)) {
+        for (const item of familyFacts) {
+            if (item.status === 'proved') {
+                assert.ok(Array.isArray(item.proof) && item.proof.length > 0, `${item.id} should have proof`);
+                assert.ok(Array.isArray(item.evidence), `${item.id} should have evidence array`);
+            }
+        }
+    }
+}
+
+assertProvedFactsHaveProof(report);
+assertProvedFactsHaveProof(mergeable);
+assertProvedFactsHaveProof(transient);
+
 console.log('ps_static_analysis_node: ok');

--- a/src/tests/ps_static_analysis_node.js
+++ b/src/tests/ps_static_analysis_node.js
@@ -15,7 +15,7 @@ OBJECTS
 Background
 black
 
-Player
+Hero
 white
 
 Goal
@@ -26,8 +26,10 @@ LEGEND
 ${'======='}
 
 . = Background
-P = Player
+P = Hero
 G = Goal
+Player = Hero
+Avatar = Hero
 
 ${'======='}
 SOUNDS
@@ -38,13 +40,13 @@ COLLISIONLAYERS
 ================
 
 Background
-Player, Goal
+Hero, Goal
 
 =====
 RULES
 =====
 
-[ > Player ] -> [ > Player ]
+[ > Hero ] -> [ > Hero ]
 
 =============
 WINCONDITIONS
@@ -69,5 +71,27 @@ assert.ok(report.facts.mergeability, 'report should include mergeability facts')
 assert.ok(report.facts.movement_action, 'report should include movement_action facts');
 assert.ok(report.facts.count_layer_invariants, 'report should include count_layer_invariants facts');
 assert.ok(report.facts.transient_boundary, 'report should include transient_boundary facts');
+assert.deepStrictEqual(
+    report.ps_tagged.objects.map(object => object.name).sort(),
+    ['Background', 'Goal', 'Hero'],
+    'ps_tagged should preserve object names'
+);
+assert.deepStrictEqual(
+    report.ps_tagged.collision_layers.map(layer => layer.objects),
+    [['Background'], ['Hero', 'Goal']],
+    'ps_tagged should preserve collision layer membership'
+);
+assert.deepStrictEqual(
+    report.ps_tagged.properties.find(property => property.name === 'avatar').members,
+    ['Hero'],
+    'ps_tagged should expose legend synonym members'
+);
+assert.strictEqual(report.ps_tagged.levels.length, 1, 'ps_tagged should summarize levels');
+assert.deepStrictEqual(
+    report.ps_tagged.objects.find(object => object.name === 'Hero').tags.present_in_all_levels,
+    true,
+    'object tags should include aggregate level presence'
+);
+assert.ok(report.ps_tagged.winconditions.length > 0, 'ps_tagged should expose win conditions');
 
 console.log('ps_static_analysis_node: ok');

--- a/src/tests/ps_static_analysis_node.js
+++ b/src/tests/ps_static_analysis_node.js
@@ -296,6 +296,18 @@ const directWinFact = directWin.facts.mergeability.find(item => item.subjects.ob
 assert.strictEqual(directWinFact.status, 'rejected');
 assert.ok(directWinFact.blockers.includes('different_win_roles'));
 
+const DUPLICATE_LAYER_GAME = MERGEABLE_GAME.replace('BodyH, BodyV, Goal', 'BodyH, BodyH, BodyV, Goal');
+const duplicateLayer = analyzeSource(DUPLICATE_LAYER_GAME, { sourcePath: 'duplicate_layer.txt' });
+assert.deepStrictEqual(
+    duplicateLayer.ps_tagged.collision_layers[1].objects,
+    ['BodyH', 'BodyV', 'Goal'],
+    'collision layer summaries should deduplicate object names'
+);
+assert.ok(
+    duplicateLayer.facts.mergeability.every(item => item.subjects.objects[0] !== item.subjects.objects[1]),
+    'mergeability should not emit self-merge facts'
+);
+
 const AUTO_TICK_GAME = SIMPLE_GAME.replace('[ > Hero ] -> [ > Hero ]', '[ Goal ] -> [ Hero ]');
 const autoTick = analyzeSource(AUTO_TICK_GAME, { sourcePath: 'auto_tick.txt' });
 const autoAction = autoTick.facts.movement_action.find(item => item.id === 'action_noop');

--- a/src/tests/ps_static_analysis_node.js
+++ b/src/tests/ps_static_analysis_node.js
@@ -381,6 +381,11 @@ assert.strictEqual(noTagged.ps_tagged, undefined, 'includePsTagged=false should 
 const onlyMerge = analyzeSource(SIMPLE_GAME, { sourcePath: 'simple.txt', familyFilter: 'mergeability' });
 assert.deepStrictEqual(Object.keys(onlyMerge.facts), ['mergeability'], 'familyFilter should keep one family');
 
+const TOO_MANY_ERRORS_GAME = SIMPLE_GAME.replace('P.G\n...', Array.from({ length: 110 }, () => 'Z').join('\n'));
+const tooManyErrors = analyzeSource(TOO_MANY_ERRORS_GAME, { sourcePath: 'too_many_errors.txt' });
+assert.strictEqual(tooManyErrors.status, 'compile_error');
+assert.ok(tooManyErrors.errors.length > 1, 'too many errors should preserve partial diagnostics');
+
 function assertProvedFactsHaveProof(reportToCheck) {
     for (const familyFacts of Object.values(reportToCheck.facts)) {
         for (const item of familyFacts) {

--- a/src/tests/ps_static_analysis_node.js
+++ b/src/tests/ps_static_analysis_node.js
@@ -405,11 +405,66 @@ const emptyClearTransient = analyzeSource(EMPTY_CLEAR_TRANSIENT_GAME, { sourcePa
 const emptyClearMark = emptyClearTransient.facts.transient_boundary.find(item => item.id === 'object_Mark_end_turn_transient');
 assert.strictEqual(emptyClearMark.status, 'proved', 'empty RHS cleanup should count as an end-turn clear');
 
+const AGAIN_PRESERVE_TRANSIENT_GAME = TRANSIENT_GAME.replace(
+    '[ Player ] -> [ Player Mark ]',
+    '[ Player no Mark ] -> [ Player Mark ]\n[ Player Mark ] -> [ Player Mark ] again'
+);
+const againPreserveTransient = analyzeSource(AGAIN_PRESERVE_TRANSIENT_GAME, { sourcePath: 'again_preserve_transient.txt' });
+const againPreserveMark = againPreserveTransient.facts.transient_boundary.find(item => item.id === 'object_Mark_end_turn_transient');
+assert.strictEqual(againPreserveMark.status, 'proved', 'rules that only preserve a transient object should not count as creators');
+
 const AGAIN_TAINT_GAME = TRANSIENT_GAME.replace('[ Player ] -> [ Player Mark ]', '[ Player ] -> [ Player Mark ] again');
 const againTaint = analyzeSource(AGAIN_TAINT_GAME, { sourcePath: 'again_taint.txt' });
 const againMark = againTaint.facts.transient_boundary.find(item => item.id === 'object_Mark_end_turn_transient');
 assert.strictEqual(againMark.status, 'rejected');
 assert.ok(againMark.blockers.includes('has_again_taint'));
+
+const LATE_CHAIN_TRANSIENT_GAME = `
+title Late Chain Transient
+========
+OBJECTS
+========
+Background
+black
+Player
+white
+Door
+red
+Mark
+pink
+${'======='}
+LEGEND
+${'======='}
+. = Background
+P = Player
+D = Door
+M = Mark
+${'======='}
+SOUNDS
+${'======='}
+================
+COLLISIONLAYERS
+================
+Background
+Player
+Door, Mark
+=====
+RULES
+=====
+late [ Door ] -> [ Mark ]
+late [ Mark ] -> [ Door ]
+=============
+WINCONDITIONS
+=============
+Some Player
+======
+LEVELS
+======
+PD
+`;
+const lateChainTransient = analyzeSource(LATE_CHAIN_TRANSIENT_GAME, { sourcePath: 'late_chain_transient.txt' });
+const lateChainMark = lateChainTransient.facts.transient_boundary.find(item => item.id === 'object_Mark_end_turn_transient');
+assert.strictEqual(lateChainMark.status, 'proved', 'late-created objects cleared by a later late rule should be end-turn transient');
 
 const noTagged = analyzeSource(SIMPLE_GAME, { sourcePath: 'simple.txt', includePsTagged: false });
 assert.strictEqual(noTagged.ps_tagged, undefined, 'includePsTagged=false should remove ps_tagged');

--- a/src/tests/ps_static_analysis_node.js
+++ b/src/tests/ps_static_analysis_node.js
@@ -295,4 +295,22 @@ const directWinFact = directWin.facts.mergeability.find(item => item.subjects.ob
 assert.strictEqual(directWinFact.status, 'rejected');
 assert.ok(directWinFact.blockers.includes('different_win_roles'));
 
+const AUTO_TICK_GAME = SIMPLE_GAME.replace('[ > Hero ] -> [ > Hero ]', '[ Goal ] -> [ Hero ]');
+const autoTick = analyzeSource(AUTO_TICK_GAME, { sourcePath: 'auto_tick.txt' });
+const autoAction = autoTick.facts.movement_action.find(item => item.id === 'action_noop');
+assert.strictEqual(autoAction.status, 'rejected');
+assert.ok(autoAction.blockers.includes('autonomous_solver_active_rule'));
+
+const ACTION_RULE_GAME = SIMPLE_GAME.replace('[ > Hero ] -> [ > Hero ]', '[ action Player ] -> [ Player Goal ]');
+const actionRule = analyzeSource(ACTION_RULE_GAME, { sourcePath: 'action_rule.txt' });
+const actionRuleFact = actionRule.facts.movement_action.find(item => item.id === 'action_noop');
+assert.strictEqual(actionRuleFact.status, 'rejected');
+assert.ok(actionRuleFact.blockers.includes('reads_action'));
+
+const ACTION_MOVEMENT_GAME = SIMPLE_GAME.replace('[ > Hero ] -> [ > Hero ]', '[ action Player ] -> [ > Player ]');
+const actionMovement = analyzeSource(ACTION_MOVEMENT_GAME, { sourcePath: 'action_movement.txt' });
+const actionMovementFact = actionMovement.facts.movement_action.find(item => item.id === 'action_noop');
+assert.strictEqual(actionMovementFact.status, 'rejected');
+assert.ok(actionMovementFact.blockers.includes('action_may_create_directional_movement'));
+
 console.log('ps_static_analysis_node: ok');

--- a/src/tests/ps_static_analysis_node.js
+++ b/src/tests/ps_static_analysis_node.js
@@ -94,4 +94,134 @@ assert.deepStrictEqual(
 );
 assert.ok(report.ps_tagged.winconditions.length > 0, 'ps_tagged should expose win conditions');
 
+const RULE_SHAPE_GAME = `
+title Rule Shape
+
+========
+OBJECTS
+========
+
+Background
+black
+
+Alpha
+white
+
+Beta
+red
+
+Gamma
+blue
+
+${'======='}
+LEGEND
+${'======='}
+
+. = Background
+a = Alpha
+b = Beta
+c = Gamma
+Player = Alpha
+
+${'======='}
+SOUNDS
+${'======='}
+
+================
+COLLISIONLAYERS
+================
+
+Background
+Alpha, Beta
+Gamma
+
+=====
+RULES
+=====
+
+right [ Alpha | right Beta no Gamma ] -> [ up Alpha | Beta right Gamma ]
+late [ Gamma ] -> [ no Gamma ]
+
+=============
+WINCONDITIONS
+=============
+
+Some Alpha
+
+======
+LEVELS
+======
+
+ab.
+...
+`;
+
+const ruleShape = analyzeSource(RULE_SHAPE_GAME, { sourcePath: 'rule_shape.txt' });
+const early = ruleShape.ps_tagged.rule_sections.find(section => section.name === 'early');
+const late = ruleShape.ps_tagged.rule_sections.find(section => section.name === 'late');
+assert.strictEqual(early.groups.length, 1, 'early section should contain one group');
+assert.strictEqual(late.groups.length, 1, 'late section should contain one group');
+const shapeRule = early.groups[0].rules[0];
+assert.strictEqual(shapeRule.direction, 'right');
+assert.deepStrictEqual(shapeRule.lhs[0][0], [
+    { kind: 'present', ref: { type: 'object', name: 'Alpha', canonical_name: 'alpha' }, movement: null },
+]);
+assert.deepStrictEqual(shapeRule.lhs[0][1], [
+    { kind: 'present', ref: { type: 'object', name: 'Beta', canonical_name: 'beta' }, movement: 'right' },
+    { kind: 'absent', ref: { type: 'object', name: 'Gamma', canonical_name: 'gamma' }, movement: null },
+]);
+assert.deepStrictEqual(shapeRule.rhs[0][0], [
+    { kind: 'present', ref: { type: 'object', name: 'Alpha', canonical_name: 'alpha' }, movement: 'up' },
+]);
+assert.deepStrictEqual(shapeRule.rhs[0][1], [
+    { kind: 'present', ref: { type: 'object', name: 'Beta', canonical_name: 'beta' }, movement: null },
+    { kind: 'present', ref: { type: 'object', name: 'Gamma', canonical_name: 'gamma' }, movement: 'right' },
+]);
+
+const COMMAND_GAME = `
+title Command Tags
+========
+OBJECTS
+========
+Background
+black
+Alpha
+white
+${'======='}
+LEGEND
+${'======='}
+. = Background
+a = Alpha
+Player = Alpha
+${'======='}
+SOUNDS
+${'======='}
+================
+COLLISIONLAYERS
+================
+Background
+Alpha
+=====
+RULES
+=====
+[ Alpha ] -> sfx0
+[ Alpha ] -> checkpoint
+=============
+WINCONDITIONS
+=============
+Some Alpha
+======
+LEVELS
+======
+a
+`;
+
+const commandReport = analyzeSource(COMMAND_GAME, { sourcePath: 'commands.txt' });
+const commandRules = commandReport.ps_tagged.rule_sections[0].groups.flatMap(group => group.rules);
+assert.strictEqual(commandRules.length, 2, 'command-only rules should remain present');
+assert.strictEqual(commandRules[0].tags.inert_command_only, true, 'sfx-only rule is inert for solver state');
+assert.strictEqual(commandRules[0].tags.solver_state_active, false, 'sfx-only rule is not solver-state active');
+assert.strictEqual(commandRules[1].tags.command_only, true, 'checkpoint-only rule is command-only');
+assert.strictEqual(commandRules[1].tags.solver_state_active, true, 'checkpoint is semantic/metagame-active');
+
 console.log('ps_static_analysis_node: ok');

--- a/src/tests/ps_static_analysis_node.js
+++ b/src/tests/ps_static_analysis_node.js
@@ -1,0 +1,73 @@
+#!/usr/bin/env node
+'use strict';
+
+const assert = require('assert');
+
+const { analyzeSource } = require('./ps_static_analysis');
+
+const SIMPLE_GAME = `
+title Static Analysis Simple
+
+========
+OBJECTS
+========
+
+Background
+black
+
+Player
+white
+
+Goal
+yellow
+
+${'======='}
+LEGEND
+${'======='}
+
+. = Background
+P = Player
+G = Goal
+
+${'======='}
+SOUNDS
+${'======='}
+
+================
+COLLISIONLAYERS
+================
+
+Background
+Player, Goal
+
+=====
+RULES
+=====
+
+[ > Player ] -> [ > Player ]
+
+=============
+WINCONDITIONS
+=============
+
+Some Player on Goal
+
+======
+LEVELS
+======
+
+P.G
+...
+`;
+
+const report = analyzeSource(SIMPLE_GAME, { sourcePath: 'simple.txt' });
+assert.strictEqual(report.schema, 'ps-static-analysis-v1');
+assert.strictEqual(report.status, 'ok');
+assert.strictEqual(report.source.path, 'simple.txt');
+assert.ok(report.ps_tagged, 'report should include ps_tagged by default');
+assert.ok(report.facts.mergeability, 'report should include mergeability facts');
+assert.ok(report.facts.movement_action, 'report should include movement_action facts');
+assert.ok(report.facts.count_layer_invariants, 'report should include count_layer_invariants facts');
+assert.ok(report.facts.transient_boundary, 'report should include transient_boundary facts');
+
+console.log('ps_static_analysis_node: ok');

--- a/src/tests/ps_static_analysis_node.js
+++ b/src/tests/ps_static_analysis_node.js
@@ -323,4 +323,56 @@ const goalCount = spawnReport.facts.count_layer_invariants.find(item => item.id 
 assert.strictEqual(goalCount.status, 'rejected');
 assert.ok(goalCount.blockers.includes('object_written_by_solver_active_rule'));
 
+const TRANSIENT_GAME = `
+title Transient
+========
+OBJECTS
+========
+Background
+black
+Player
+white
+Mark
+red
+${'======='}
+LEGEND
+${'======='}
+. = Background
+P = Player
+M = Mark
+${'======='}
+SOUNDS
+${'======='}
+================
+COLLISIONLAYERS
+================
+Background
+Player
+Mark
+=====
+RULES
+=====
+[ Player ] -> [ Player Mark ]
+late [ Mark ] -> [ no Mark ]
+=============
+WINCONDITIONS
+=============
+Some Player
+======
+LEVELS
+======
+P
+`;
+
+const transient = analyzeSource(TRANSIENT_GAME, { sourcePath: 'transient.txt' });
+const markTransient = transient.facts.transient_boundary.find(item => item.id === 'object_Mark_end_turn_transient');
+assert.strictEqual(markTransient.status, 'proved');
+assert.strictEqual(markTransient.tags.single_turn_only, true);
+
+const AGAIN_TAINT_GAME = TRANSIENT_GAME.replace('[ Player ] -> [ Player Mark ]', '[ Player ] -> [ Player Mark ] again');
+const againTaint = analyzeSource(AGAIN_TAINT_GAME, { sourcePath: 'again_taint.txt' });
+const againMark = againTaint.facts.transient_boundary.find(item => item.id === 'object_Mark_end_turn_transient');
+assert.strictEqual(againMark.status, 'rejected');
+assert.ok(againMark.blockers.includes('has_again_taint'));
+
 console.log('ps_static_analysis_node: ok');

--- a/src/tests/ps_static_analysis_node.js
+++ b/src/tests/ps_static_analysis_node.js
@@ -313,4 +313,14 @@ const actionMovementFact = actionMovement.facts.movement_action.find(item => ite
 assert.strictEqual(actionMovementFact.status, 'rejected');
 assert.ok(actionMovementFact.blockers.includes('action_may_create_directional_movement'));
 
+const countFacts = report.facts.count_layer_invariants;
+assert.ok(countFacts.some(item => item.id === 'object_Hero_count_preserved'), 'Hero count fact should exist');
+assert.ok(countFacts.some(item => item.id === 'layer_0_static'), 'Background layer static fact should exist');
+
+const SPAWN_GAME = SIMPLE_GAME.replace('[ > Hero ] -> [ > Hero ]', '[ Hero ] -> [ Hero Goal ]');
+const spawnReport = analyzeSource(SPAWN_GAME, { sourcePath: 'spawn.txt' });
+const goalCount = spawnReport.facts.count_layer_invariants.find(item => item.id === 'object_Goal_count_preserved');
+assert.strictEqual(goalCount.status, 'rejected');
+assert.ok(goalCount.blockers.includes('object_written_by_solver_active_rule'));
+
 console.log('ps_static_analysis_node: ok');

--- a/src/tests/ps_static_analysis_node.js
+++ b/src/tests/ps_static_analysis_node.js
@@ -164,18 +164,18 @@ assert.strictEqual(late.groups.length, 1, 'late section should contain one group
 const shapeRule = early.groups[0].rules[0];
 assert.strictEqual(shapeRule.direction, 'right');
 assert.deepStrictEqual(shapeRule.lhs[0][0], [
-    { kind: 'present', ref: { type: 'object', name: 'Alpha', canonical_name: 'alpha' }, movement: null },
+    { kind: 'present', ref: { type: 'object', name: 'Alpha', canonical_name: 'alpha' }, movement: null, expanded_objects: ['Alpha'] },
 ]);
 assert.deepStrictEqual(shapeRule.lhs[0][1], [
-    { kind: 'present', ref: { type: 'object', name: 'Beta', canonical_name: 'beta' }, movement: 'right' },
-    { kind: 'absent', ref: { type: 'object', name: 'Gamma', canonical_name: 'gamma' }, movement: null },
+    { kind: 'present', ref: { type: 'object', name: 'Beta', canonical_name: 'beta' }, movement: 'right', expanded_objects: ['Beta'] },
+    { kind: 'absent', ref: { type: 'object', name: 'Gamma', canonical_name: 'gamma' }, movement: null, expanded_objects: ['Gamma'] },
 ]);
 assert.deepStrictEqual(shapeRule.rhs[0][0], [
-    { kind: 'present', ref: { type: 'object', name: 'Alpha', canonical_name: 'alpha' }, movement: 'up' },
+    { kind: 'present', ref: { type: 'object', name: 'Alpha', canonical_name: 'alpha' }, movement: 'up', expanded_objects: ['Alpha'] },
 ]);
 assert.deepStrictEqual(shapeRule.rhs[0][1], [
-    { kind: 'present', ref: { type: 'object', name: 'Beta', canonical_name: 'beta' }, movement: null },
-    { kind: 'present', ref: { type: 'object', name: 'Gamma', canonical_name: 'gamma' }, movement: 'right' },
+    { kind: 'present', ref: { type: 'object', name: 'Beta', canonical_name: 'beta' }, movement: null, expanded_objects: ['Beta'] },
+    { kind: 'present', ref: { type: 'object', name: 'Gamma', canonical_name: 'gamma' }, movement: 'right', expanded_objects: ['Gamma'] },
 ]);
 
 const COMMAND_GAME = `
@@ -223,5 +223,76 @@ assert.strictEqual(commandRules[0].tags.inert_command_only, true, 'sfx-only rule
 assert.strictEqual(commandRules[0].tags.solver_state_active, false, 'sfx-only rule is not solver-state active');
 assert.strictEqual(commandRules[1].tags.command_only, true, 'checkpoint-only rule is command-only');
 assert.strictEqual(commandRules[1].tags.solver_state_active, true, 'checkpoint is semantic/metagame-active');
+
+const MERGEABLE_GAME = `
+title Mergeable
+========
+OBJECTS
+========
+Background
+black
+BodyH
+white
+BodyV
+white
+Goal
+yellow
+${'======='}
+LEGEND
+${'======='}
+. = Background
+h = BodyH
+v = BodyV
+g = Goal
+Player = BodyH or BodyV
+Body = BodyH or BodyV
+${'======='}
+SOUNDS
+${'======='}
+================
+COLLISIONLAYERS
+================
+Background
+BodyH, BodyV, Goal
+=====
+RULES
+=====
+[ Body ] -> [ Body ]
+[ no Body ] -> [ no Body ]
+[ > Body ] -> [ > Body ]
+=============
+WINCONDITIONS
+=============
+Some Body on Goal
+======
+LEVELS
+======
+h.g
+`;
+
+const mergeable = analyzeSource(MERGEABLE_GAME, { sourcePath: 'mergeable.txt' });
+const mergeFact = mergeable.facts.mergeability.find(item => item.subjects.objects.join(',') === 'BodyH,BodyV');
+assert.ok(mergeFact, 'BodyH/BodyV should produce a mergeability fact');
+assert.strictEqual(mergeFact.status, 'candidate');
+assert.ok(mergeFact.proof.includes('same_collision_layer'));
+assert.ok(mergeFact.proof.includes('observed_only_through_shared_sets'));
+
+const DIRECT_READ_GAME = MERGEABLE_GAME.replace('[ Body ] -> [ Body ]', '[ BodyH ] -> [ BodyH ]');
+const directRead = analyzeSource(DIRECT_READ_GAME, { sourcePath: 'direct_read.txt' });
+const directReadFact = directRead.facts.mergeability.find(item => item.subjects.objects.join(',') === 'BodyH,BodyV');
+assert.strictEqual(directReadFact.status, 'rejected');
+assert.ok(directReadFact.blockers.includes('individual_lhs_read'));
+
+const DIRECT_NEGATION_GAME = MERGEABLE_GAME.replace('[ no Body ] -> [ no Body ]', '[ no BodyH ] -> [ no BodyH ]');
+const directNegation = analyzeSource(DIRECT_NEGATION_GAME, { sourcePath: 'direct_negation.txt' });
+const directNegationFact = directNegation.facts.mergeability.find(item => item.subjects.objects.join(',') === 'BodyH,BodyV');
+assert.strictEqual(directNegationFact.status, 'rejected');
+assert.ok(directNegationFact.blockers.includes('individual_lhs_read'));
+
+const DIRECT_WIN_GAME = MERGEABLE_GAME.replace('Some Body on Goal', 'Some BodyH on Goal');
+const directWin = analyzeSource(DIRECT_WIN_GAME, { sourcePath: 'direct_win.txt' });
+const directWinFact = directWin.facts.mergeability.find(item => item.subjects.objects.join(',') === 'BodyH,BodyV');
+assert.strictEqual(directWinFact.status, 'rejected');
+assert.ok(directWinFact.blockers.includes('different_win_roles'));
 
 console.log('ps_static_analysis_node: ok');

--- a/src/tests/run_ps_static_analysis.js
+++ b/src/tests/run_ps_static_analysis.js
@@ -4,7 +4,7 @@
 const fs = require('fs');
 const path = require('path');
 
-const { analyzePaths } = require('./ps_static_analysis');
+const { analyzeFile, discoverInputFiles } = require('./ps_static_analysis');
 
 function usage() {
     console.error([
@@ -43,17 +43,36 @@ for (let index = 0; index < args.length; index++) {
     }
 }
 
-const reports = analyzePaths(inputs, options);
-const output = {
-    schema: 'ps-static-analysis-batch-v1',
-    generated_at: new Date().toISOString(),
-    source_count: reports.length,
-    reports,
-};
+const files = discoverInputFiles(inputs)
+    .filter(filePath => !options.gameFilter || filePath.toLowerCase().includes(options.gameFilter.toLowerCase()));
 
-const json = `${JSON.stringify(output, null, 2)}\n`;
+function writeIndentedJson(write, value, indent) {
+    const prefix = ' '.repeat(indent);
+    const json = JSON.stringify(value, null, 2).split('\n').map(line => `${prefix}${line}`).join('\n');
+    write(json);
+}
+
+function writeBatch(write) {
+    write('{\n');
+    write('  "schema": "ps-static-analysis-batch-v1",\n');
+    write(`  "generated_at": ${JSON.stringify(new Date().toISOString())},\n`);
+    write(`  "source_count": ${files.length},\n`);
+    write('  "reports": [\n');
+    files.forEach((filePath, index) => {
+        if (index > 0) write(',\n');
+        writeIndentedJson(write, analyzeFile(filePath, options), 4);
+    });
+    write('\n  ]\n');
+    write('}\n');
+}
+
 if (outPath) {
-    fs.writeFileSync(outPath, json);
+    const fd = fs.openSync(outPath, 'w');
+    try {
+        writeBatch(chunk => fs.writeSync(fd, chunk));
+    } finally {
+        fs.closeSync(fd);
+    }
 } else {
-    process.stdout.write(json);
+    writeBatch(chunk => process.stdout.write(chunk));
 }

--- a/src/tests/run_ps_static_analysis.js
+++ b/src/tests/run_ps_static_analysis.js
@@ -1,0 +1,40 @@
+#!/usr/bin/env node
+'use strict';
+
+const fs = require('fs');
+const path = require('path');
+
+const { analyzeFile } = require('./ps_static_analysis');
+
+function usage() {
+    console.error('Usage: node src/tests/run_ps_static_analysis.js <file.txt> [--out PATH] [--no-ps-tagged]');
+    process.exit(1);
+}
+
+const args = process.argv.slice(2);
+if (args.length === 0 || args.includes('--help') || args.includes('-h')) {
+    usage();
+}
+
+const inputPath = args[0];
+const options = { includePsTagged: true };
+let outPath = null;
+
+for (let index = 1; index < args.length; index++) {
+    const arg = args[index];
+    if (arg === '--out' && index + 1 < args.length) {
+        outPath = path.resolve(args[++index]);
+    } else if (arg === '--no-ps-tagged') {
+        options.includePsTagged = false;
+    } else {
+        throw new Error(`Unsupported argument: ${arg}`);
+    }
+}
+
+const report = analyzeFile(inputPath, options);
+const json = `${JSON.stringify(report, null, 2)}\n`;
+if (outPath) {
+    fs.writeFileSync(outPath, json);
+} else {
+    process.stdout.write(json);
+}

--- a/src/tests/run_ps_static_analysis.js
+++ b/src/tests/run_ps_static_analysis.js
@@ -4,10 +4,14 @@
 const fs = require('fs');
 const path = require('path');
 
-const { analyzeFile } = require('./ps_static_analysis');
+const { analyzePaths } = require('./ps_static_analysis');
 
 function usage() {
-    console.error('Usage: node src/tests/run_ps_static_analysis.js <file.txt> [--out PATH] [--no-ps-tagged]');
+    console.error([
+        'Usage: node src/tests/run_ps_static_analysis.js <file-or-dir> [more paths]',
+        '  [--out PATH] [--family NAME] [--game SUBSTRING]',
+        '  [--include-ps-tagged] [--no-ps-tagged]',
+    ].join('\n'));
     process.exit(1);
 }
 
@@ -16,23 +20,38 @@ if (args.length === 0 || args.includes('--help') || args.includes('-h')) {
     usage();
 }
 
-const inputPath = args[0];
-const options = { includePsTagged: true };
+const inputs = [];
+const options = { includePsTagged: true, familyFilter: null, gameFilter: null };
 let outPath = null;
 
-for (let index = 1; index < args.length; index++) {
+for (let index = 0; index < args.length; index++) {
     const arg = args[index];
     if (arg === '--out' && index + 1 < args.length) {
         outPath = path.resolve(args[++index]);
+    } else if (arg === '--family' && index + 1 < args.length) {
+        options.familyFilter = args[++index];
+    } else if (arg === '--game' && index + 1 < args.length) {
+        options.gameFilter = args[++index];
+    } else if (arg === '--include-ps-tagged') {
+        options.includePsTagged = true;
     } else if (arg === '--no-ps-tagged') {
         options.includePsTagged = false;
-    } else {
+    } else if (arg.startsWith('--')) {
         throw new Error(`Unsupported argument: ${arg}`);
+    } else {
+        inputs.push(arg);
     }
 }
 
-const report = analyzeFile(inputPath, options);
-const json = `${JSON.stringify(report, null, 2)}\n`;
+const reports = analyzePaths(inputs, options);
+const output = {
+    schema: 'ps-static-analysis-batch-v1',
+    generated_at: new Date().toISOString(),
+    source_count: reports.length,
+    reports,
+};
+
+const json = `${JSON.stringify(output, null, 2)}\n`;
 if (outPath) {
     fs.writeFileSync(outPath, json);
 } else {


### PR DESCRIPTION
## Summary
- Add a source-preserving `ps_tagged` static analyzer and batch CLI.
- Derive mergeability, movement/action, count/layer invariant, and transient-boundary fact families.
- Add fixture coverage plus corpus validation over demo and solver test games.
- Stream batch JSON output so full `--include-ps-tagged` corpus exports do not hit V8 string-size limits.
- Preserve parser diagnostics when compilation aborts after too many errors/warnings.

## Stack
- Parent PR: #1147
- Base branch: `codex/cpp-native-game-session-state-model`
- This PR intentionally contains only the static analyzer delta on top of that parent branch.

## Validation
- `node --check src/tests/ps_static_analysis.js`
- `node --check src/tests/run_ps_static_analysis.js`
- `node --check src/tests/ps_static_analysis_node.js`
- `node src/tests/canonicalizer_node.js`
- `node src/tests/ps_static_analysis_node.js`
- `npm run test:node`: 742 passed, 0 failed
- `make solver_smoke_tests`: passed 7 cases
- `make solver_parity_smoke`: passed 7 cases
- `make simulation_tests_cpp`: 469 passed
- `make generator_smoke_tests`: passed
- `make solver_tests_cpp`: passed, 865/1506 solved, 606 timeout, 35 unsolvable
- `make solver_determinism_tests`: passed, `runs=5 plus_jobs_auto=1`

## Corpus Checks
- `node src/tests/run_ps_static_analysis.js src/demo src/tests/solver_tests --no-ps-tagged --out /private/tmp/ps_static_corpus.json`
  - 278 sources, 276 ok, 2 compile_error
  - `a distant sunset.txt` compile-error report now preserves 102 collected diagnostics instead of only the abort message
- `node src/tests/run_ps_static_analysis.js src/demo src/tests/solver_tests --include-ps-tagged --out /private/tmp/ps_static_corpus_full.json`
  - 278 sources, 276 ok, 2 compile_error
  - produced valid JSON, 580 MB
- `node src/tests/run_ps_static_analysis.js src/demo/limerick.txt --family mergeability --out /private/tmp/ps_static_limerick_merge.json`
  - reports `PlayerBodyH` / `PlayerBodyV` as a mergeability candidate
