### PR TITLE
Static analyser: rule tag fixtures + program_flow wake graph

### DIFF
--- a/src/tests/static_analysis_testdata/rule_tags/movement-action-on-property.json
+++ b/src/tests/static_analysis_testdata/rule_tags/movement-action-on-property.json
@@ -1,0 +1,18 @@
+{
+  "schema": "ps-static-analysis-testdata-v1",
+  "ruleTag": [
+    {
+      "line": 76,
+      "text": "[ action sibling1_or_sibling2 ] -> [ sibling1_or_sibling2 ]",
+      "tags": {
+        "objects_matched": ["Sibling1", "Sibling2"],
+        "objects_written": [],
+        "objects_erased": [],
+        "movements_required": [],
+        "movements_matched": ["Sibling1:action", "Sibling2:action"],
+        "movements_written": ["Sibling1:stationary", "Sibling2:stationary"],
+        "movements_removed": ["Sibling1:action", "Sibling2:action"]
+      }
+    }
+  ]
+}

--- a/src/tests/static_analysis_testdata/rule_tags/movement-action-on-property.txt
+++ b/src/tests/static_analysis_testdata/rule_tags/movement-action-on-property.txt
@@ -1,0 +1,88 @@
+title Static Analysis Rule Tag Movement Action On Property
+
+========
+OBJECTS
+========
+
+Background
+black
+
+Target
+yellow
+
+Player
+white
+
+Wall
+brown
+
+Crate
+orange
+
+Alpha
+red
+
+Beta
+blue
+
+Gamma
+green
+
+Orphan1
+lightblue
+
+Sibling1
+purple
+
+Sibling2
+pink
+
+========
+LEGEND
+========
+
+. = Background
+T = Target
+P = Player
+# = Wall
+C = Crate
+A = Alpha
+B = Beta
+G = Gamma
+O = Orphan1
+X = Sibling1
+Y = Sibling2
+Sibling1_or_Sibling2 = Sibling1 or Sibling2
+
+========
+SOUNDS
+========
+
+================
+COLLISIONLAYERS
+================
+
+Background
+Target
+Player, Wall, Crate
+Alpha, Beta, Gamma
+Orphan1
+Sibling1, Sibling2
+
+=====
+RULES
+=====
+
+[ action sibling1_or_sibling2 ] -> [ sibling1_or_sibling2 ]
+
+=============
+WINCONDITIONS
+=============
+
+Some Player
+
+======
+LEVELS
+======
+
+TP#CABGOXY

--- a/src/tests/static_analysis_testdata/rule_tags/movement-action-write.json
+++ b/src/tests/static_analysis_testdata/rule_tags/movement-action-write.json
@@ -1,0 +1,19 @@
+{
+  "schema": "ps-static-analysis-testdata-v1",
+  "ruleTag": [
+    {
+      "line": 66,
+      "text": "[ action player ] -> [ player stationary orphan1 ]",
+      "tags": {
+        "objects_required": ["Player"],
+        "objects_matched": ["Player"],
+        "movements_required": ["Player:action"],
+        "movements_matched": ["Player:action"],
+        "objects_written": ["Orphan1"],
+        "objects_erased": [],
+        "movements_written": ["Orphan1:stationary", "Player:stationary"],
+        "movements_removed": ["Player:action"]
+      }
+    }
+  ]
+}

--- a/src/tests/static_analysis_testdata/rule_tags/movement-action-write.txt
+++ b/src/tests/static_analysis_testdata/rule_tags/movement-action-write.txt
@@ -1,0 +1,78 @@
+title Static Analysis Rule Tag Movement Action Write
+
+========
+OBJECTS
+========
+
+Background
+black
+
+Target
+yellow
+
+Player
+white
+
+Wall
+brown
+
+Crate
+orange
+
+Alpha
+red
+
+Beta
+blue
+
+Gamma
+green
+
+Orphan1
+lightblue
+
+========
+LEGEND
+========
+
+. = Background
+T = Target
+P = Player
+# = Wall
+C = Crate
+A = Alpha
+B = Beta
+G = Gamma
+O = Orphan1
+
+========
+SOUNDS
+========
+
+================
+COLLISIONLAYERS
+================
+
+Background
+Target
+Player, Wall, Crate
+Alpha, Beta, Gamma
+Orphan1
+
+=====
+RULES
+=====
+
+[ action player ] -> [ player stationary orphan1 ]
+
+=============
+WINCONDITIONS
+=============
+
+Some Player
+
+======
+LEVELS
+======
+
+TP#CABGO

--- a/src/tests/static_analysis_testdata/rule_tags/movement-ellipsis.json
+++ b/src/tests/static_analysis_testdata/rule_tags/movement-ellipsis.json
@@ -1,0 +1,17 @@
+{
+  "schema": "ps-static-analysis-testdata-v1",
+  "ruleTag": [
+    {
+      "line": 61,
+      "text": "right [ player | ... | crate ] -> [ player | ... | right crate ]",
+      "tags": {
+        "objects_required": ["Crate", "Player"],
+        "objects_matched": ["Crate", "Player"],
+        "objects_written": [],
+        "objects_erased": [],
+        "movements_written": ["Crate:right"],
+        "movements_removed": ["Crate:action", "Crate:down", "Crate:left", "Crate:stationary", "Crate:up"]
+      }
+    }
+  ]
+}

--- a/src/tests/static_analysis_testdata/rule_tags/movement-ellipsis.txt
+++ b/src/tests/static_analysis_testdata/rule_tags/movement-ellipsis.txt
@@ -1,0 +1,73 @@
+title Static Analysis Rule Tag Movement Ellipsis
+
+========
+OBJECTS
+========
+
+Background
+black
+
+Target
+yellow
+
+Player
+white
+
+Wall
+brown
+
+Crate
+orange
+
+Alpha
+red
+
+Beta
+blue
+
+Gamma
+green
+
+========
+LEGEND
+========
+
+. = Background
+T = Target
+P = Player
+# = Wall
+C = Crate
+A = Alpha
+B = Beta
+G = Gamma
+
+========
+SOUNDS
+========
+
+================
+COLLISIONLAYERS
+================
+
+Background
+Target
+Player, Wall, Crate
+Alpha, Beta, Gamma
+
+=====
+RULES
+=====
+
+right [ player | ... | crate ] -> [ player | ... | right crate ]
+
+=============
+WINCONDITIONS
+=============
+
+Some Player
+
+======
+LEVELS
+======
+
+TP#CABG

--- a/src/tests/static_analysis_testdata/rule_tags/movement-push-chain.json
+++ b/src/tests/static_analysis_testdata/rule_tags/movement-push-chain.json
@@ -1,0 +1,15 @@
+{
+  "schema": "ps-static-analysis-testdata-v1",
+  "ruleTag": [
+    {
+      "line": 61,
+      "text": "right [ right player | crate ] -> [ right player | right crate ]",
+      "tags": {
+        "movements_required": ["Player:right"],
+        "movements_matched": ["Player:right"],
+        "movements_written": ["Crate:right"],
+        "movements_removed": ["Crate:action", "Crate:down", "Crate:left", "Crate:stationary", "Crate:up"]
+      }
+    }
+  ]
+}

--- a/src/tests/static_analysis_testdata/rule_tags/movement-push-chain.txt
+++ b/src/tests/static_analysis_testdata/rule_tags/movement-push-chain.txt
@@ -1,0 +1,73 @@
+title Static Analysis Rule Tag Movement Push Chain
+
+========
+OBJECTS
+========
+
+Background
+black
+
+Target
+yellow
+
+Player
+white
+
+Wall
+brown
+
+Crate
+orange
+
+Alpha
+red
+
+Beta
+blue
+
+Gamma
+green
+
+========
+LEGEND
+========
+
+. = Background
+T = Target
+P = Player
+# = Wall
+C = Crate
+A = Alpha
+B = Beta
+G = Gamma
+
+========
+SOUNDS
+========
+
+================
+COLLISIONLAYERS
+================
+
+Background
+Target
+Player, Wall, Crate
+Alpha, Beta, Gamma
+
+=====
+RULES
+=====
+
+right [ right player | crate ] -> [ right player | right crate ]
+
+=============
+WINCONDITIONS
+=============
+
+Some Player
+
+======
+LEVELS
+======
+
+TP#CABG

--- a/src/tests/static_analysis_testdata/rule_tags/rhs-absent-adjacent-cell.json
+++ b/src/tests/static_analysis_testdata/rule_tags/rhs-absent-adjacent-cell.json
@@ -1,0 +1,18 @@
+{
+  "schema": "ps-static-analysis-testdata-v1",
+  "ruleTag": [
+    {
+      "line": 66,
+      "text": "right [ player | no orphan1 ] -> [ player | stationary orphan1 ]",
+      "tags": {
+        "objects_required": ["Player"],
+        "objects_matched": ["Player"],
+        "object_absences_matched": ["Orphan1"],
+        "objects_written": ["Orphan1"],
+        "objects_erased": [],
+        "movements_written": ["Orphan1:stationary"],
+        "movements_removed": []
+      }
+    }
+  ]
+}

--- a/src/tests/static_analysis_testdata/rule_tags/rhs-absent-adjacent-cell.txt
+++ b/src/tests/static_analysis_testdata/rule_tags/rhs-absent-adjacent-cell.txt
@@ -1,0 +1,78 @@
+title Static Analysis Rule Tag RHS Absent Adjacent Cell
+
+========
+OBJECTS
+========
+
+Background
+black
+
+Target
+yellow
+
+Player
+white
+
+Wall
+brown
+
+Crate
+orange
+
+Alpha
+red
+
+Beta
+blue
+
+Gamma
+green
+
+Orphan1
+lightblue
+
+========
+LEGEND
+========
+
+. = Background
+T = Target
+P = Player
+# = Wall
+C = Crate
+A = Alpha
+B = Beta
+G = Gamma
+O = Orphan1
+
+========
+SOUNDS
+========
+
+================
+COLLISIONLAYERS
+================
+
+Background
+Target
+Player, Wall, Crate
+Alpha, Beta, Gamma
+Orphan1
+
+=====
+RULES
+=====
+
+right [ player | no orphan1 ] -> [ player | stationary orphan1 ]
+
+=============
+WINCONDITIONS
+=============
+
+Some Player
+
+======
+LEVELS
+======
+
+TP#CABGO

--- a/src/tests/static_analysis_testdata/rule_tags/rhs-inferred-property-absent-guard.json
+++ b/src/tests/static_analysis_testdata/rule_tags/rhs-inferred-property-absent-guard.json
@@ -1,0 +1,17 @@
+{
+  "schema": "ps-static-analysis-testdata-v1",
+  "ruleTag": [
+    {
+      "line": 76,
+      "text": "[ sibling1_or_sibling2 no orphan1 ] -> [ sibling1_or_sibling2 stationary orphan1 ]",
+      "tags": {
+        "objects_matched": ["Sibling1", "Sibling2"],
+        "object_absences_matched": ["Orphan1"],
+        "objects_written": ["Orphan1"],
+        "objects_erased": [],
+        "movements_written": ["Orphan1:stationary"],
+        "movements_removed": []
+      }
+    }
+  ]
+}

--- a/src/tests/static_analysis_testdata/rule_tags/rhs-inferred-property-absent-guard.txt
+++ b/src/tests/static_analysis_testdata/rule_tags/rhs-inferred-property-absent-guard.txt
@@ -1,0 +1,88 @@
+title Static Analysis Rule Tag RHS Inferred Property Absent Guard
+
+========
+OBJECTS
+========
+
+Background
+black
+
+Target
+yellow
+
+Player
+white
+
+Wall
+brown
+
+Crate
+orange
+
+Alpha
+red
+
+Beta
+blue
+
+Gamma
+green
+
+Orphan1
+lightblue
+
+Sibling1
+purple
+
+Sibling2
+pink
+
+========
+LEGEND
+========
+
+. = Background
+T = Target
+P = Player
+# = Wall
+C = Crate
+A = Alpha
+B = Beta
+G = Gamma
+O = Orphan1
+X = Sibling1
+Y = Sibling2
+Sibling1_or_Sibling2 = Sibling1 or Sibling2
+
+========
+SOUNDS
+========
+
+================
+COLLISIONLAYERS
+================
+
+Background
+Target
+Player, Wall, Crate
+Alpha, Beta, Gamma
+Orphan1
+Sibling1, Sibling2
+
+=====
+RULES
+=====
+
+[ sibling1_or_sibling2 no orphan1 ] -> [ sibling1_or_sibling2 stationary orphan1 ]
+
+=============
+WINCONDITIONS
+=============
+
+Some Player
+
+======
+LEVELS
+======
+
+TP#CABGOXY

--- a/src/tests/static_analysis_testdata/rule_tags/rhs-inferred-property-deleted.json
+++ b/src/tests/static_analysis_testdata/rule_tags/rhs-inferred-property-deleted.json
@@ -1,0 +1,14 @@
+{
+  "schema": "ps-static-analysis-testdata-v1",
+  "ruleTag": [
+    {
+      "line": 76,
+      "text": "[ sibling1_or_sibling2 ] -> [ ]",
+      "tags": {
+        "objects_matched": ["Sibling1", "Sibling2"],
+        "objects_written": [],
+        "objects_erased": ["Sibling1", "Sibling2"]
+      }
+    }
+  ]
+}

--- a/src/tests/static_analysis_testdata/rule_tags/rhs-inferred-property-deleted.txt
+++ b/src/tests/static_analysis_testdata/rule_tags/rhs-inferred-property-deleted.txt
@@ -1,0 +1,88 @@
+title Static Analysis Rule Tag RHS Inferred Property Deleted
+
+========
+OBJECTS
+========
+
+Background
+black
+
+Target
+yellow
+
+Player
+white
+
+Wall
+brown
+
+Crate
+orange
+
+Alpha
+red
+
+Beta
+blue
+
+Gamma
+green
+
+Orphan1
+lightblue
+
+Sibling1
+purple
+
+Sibling2
+pink
+
+========
+LEGEND
+========
+
+. = Background
+T = Target
+P = Player
+# = Wall
+C = Crate
+A = Alpha
+B = Beta
+G = Gamma
+O = Orphan1
+X = Sibling1
+Y = Sibling2
+Sibling1_or_Sibling2 = Sibling1 or Sibling2
+
+========
+SOUNDS
+========
+
+================
+COLLISIONLAYERS
+================
+
+Background
+Target
+Player, Wall, Crate
+Alpha, Beta, Gamma
+Orphan1
+Sibling1, Sibling2
+
+=====
+RULES
+=====
+
+[ sibling1_or_sibling2 ] -> [ ]
+
+=============
+WINCONDITIONS
+=============
+
+Some Player
+
+======
+LEVELS
+======
+
+TP#CABGOXY

--- a/src/tests/static_analysis_testdata/rule_tags/rhs-inferred-property-layer-drop.json
+++ b/src/tests/static_analysis_testdata/rule_tags/rhs-inferred-property-layer-drop.json
@@ -1,0 +1,14 @@
+{
+  "schema": "ps-static-analysis-testdata-v1",
+  "ruleTag": [
+    {
+      "line": 76,
+      "text": "[ orphan1 sibling1_or_sibling2 ] -> [ sibling1_or_sibling2 ]",
+      "tags": {
+        "objects_matched": ["Orphan1", "Sibling1", "Sibling2"],
+        "objects_written": [],
+        "objects_erased": ["Orphan1"]
+      }
+    }
+  ]
+}

--- a/src/tests/static_analysis_testdata/rule_tags/rhs-inferred-property-layer-drop.txt
+++ b/src/tests/static_analysis_testdata/rule_tags/rhs-inferred-property-layer-drop.txt
@@ -1,0 +1,88 @@
+title Static Analysis Rule Tag RHS Inferred Property Layer Drop
+
+========
+OBJECTS
+========
+
+Background
+black
+
+Target
+yellow
+
+Player
+white
+
+Wall
+brown
+
+Crate
+orange
+
+Alpha
+red
+
+Beta
+blue
+
+Gamma
+green
+
+Orphan1
+lightblue
+
+Sibling1
+purple
+
+Sibling2
+pink
+
+========
+LEGEND
+========
+
+. = Background
+T = Target
+P = Player
+# = Wall
+C = Crate
+A = Alpha
+B = Beta
+G = Gamma
+O = Orphan1
+X = Sibling1
+Y = Sibling2
+Sibling1_or_Sibling2 = Sibling1 or Sibling2
+
+========
+SOUNDS
+========
+
+================
+COLLISIONLAYERS
+================
+
+Background
+Target
+Player, Wall, Crate
+Alpha, Beta, Gamma
+Orphan1
+Sibling1, Sibling2
+
+=====
+RULES
+=====
+
+[ orphan1 sibling1_or_sibling2 ] -> [ sibling1_or_sibling2 ]
+
+=============
+WINCONDITIONS
+=============
+
+Some Player
+
+======
+LEVELS
+======
+
+TP#CABGOXY

--- a/src/tests/static_analysis_testdata/rule_tags/rhs-inferred-property-multilayer.json
+++ b/src/tests/static_analysis_testdata/rule_tags/rhs-inferred-property-multilayer.json
@@ -1,0 +1,14 @@
+{
+  "schema": "ps-static-analysis-testdata-v1",
+  "ruleTag": [
+    {
+      "line": 76,
+      "text": "[ orphan1 sibling1_or_sibling2 ] -> [ orphan1 sibling1_or_sibling2 ]",
+      "tags": {
+        "objects_matched": ["Orphan1", "Sibling1", "Sibling2"],
+        "objects_written": [],
+        "objects_erased": []
+      }
+    }
+  ]
+}

--- a/src/tests/static_analysis_testdata/rule_tags/rhs-inferred-property-multilayer.txt
+++ b/src/tests/static_analysis_testdata/rule_tags/rhs-inferred-property-multilayer.txt
@@ -1,0 +1,88 @@
+title Static Analysis Rule Tag RHS Inferred Property Multilayer
+
+========
+OBJECTS
+========
+
+Background
+black
+
+Target
+yellow
+
+Player
+white
+
+Wall
+brown
+
+Crate
+orange
+
+Alpha
+red
+
+Beta
+blue
+
+Gamma
+green
+
+Orphan1
+lightblue
+
+Sibling1
+purple
+
+Sibling2
+pink
+
+========
+LEGEND
+========
+
+. = Background
+T = Target
+P = Player
+# = Wall
+C = Crate
+A = Alpha
+B = Beta
+G = Gamma
+O = Orphan1
+X = Sibling1
+Y = Sibling2
+Sibling1_or_Sibling2 = Sibling1 or Sibling2
+
+========
+SOUNDS
+========
+
+================
+COLLISIONLAYERS
+================
+
+Background
+Target
+Player, Wall, Crate
+Alpha, Beta, Gamma
+Orphan1
+Sibling1, Sibling2
+
+=====
+RULES
+=====
+
+[ orphan1 sibling1_or_sibling2 ] -> [ orphan1 sibling1_or_sibling2 ]
+
+=============
+WINCONDITIONS
+=============
+
+Some Player
+
+======
+LEVELS
+======
+
+TP#CABGOXY

--- a/src/tests/static_analysis_testdata/rule_tags/rhs-inferred-property-replaced-by-orphan.json
+++ b/src/tests/static_analysis_testdata/rule_tags/rhs-inferred-property-replaced-by-orphan.json
@@ -1,0 +1,14 @@
+{
+  "schema": "ps-static-analysis-testdata-v1",
+  "ruleTag": [
+    {
+      "line": 76,
+      "text": "[ sibling1_or_sibling2 ] -> [ stationary orphan1 ]",
+      "tags": {
+        "objects_matched": ["Sibling1", "Sibling2"],
+        "objects_written": ["Orphan1"],
+        "objects_erased": ["Sibling1", "Sibling2"]
+      }
+    }
+  ]
+}

--- a/src/tests/static_analysis_testdata/rule_tags/rhs-inferred-property-replaced-by-orphan.txt
+++ b/src/tests/static_analysis_testdata/rule_tags/rhs-inferred-property-replaced-by-orphan.txt
@@ -1,0 +1,88 @@
+title Static Analysis Rule Tag RHS Inferred Property Replaced By Orphan
+
+========
+OBJECTS
+========
+
+Background
+black
+
+Target
+yellow
+
+Player
+white
+
+Wall
+brown
+
+Crate
+orange
+
+Alpha
+red
+
+Beta
+blue
+
+Gamma
+green
+
+Orphan1
+lightblue
+
+Sibling1
+purple
+
+Sibling2
+pink
+
+========
+LEGEND
+========
+
+. = Background
+T = Target
+P = Player
+# = Wall
+C = Crate
+A = Alpha
+B = Beta
+G = Gamma
+O = Orphan1
+X = Sibling1
+Y = Sibling2
+Sibling1_or_Sibling2 = Sibling1 or Sibling2
+
+========
+SOUNDS
+========
+
+================
+COLLISIONLAYERS
+================
+
+Background
+Target
+Player, Wall, Crate
+Alpha, Beta, Gamma
+Orphan1
+Sibling1, Sibling2
+
+=====
+RULES
+=====
+
+[ sibling1_or_sibling2 ] -> [ stationary orphan1 ]
+
+=============
+WINCONDITIONS
+=============
+
+Some Player
+
+======
+LEVELS
+======
+
+TP#CABGOXY

--- a/src/tests/static_analysis_testdata/rule_tags/rhs-inferred-property-second-cell.json
+++ b/src/tests/static_analysis_testdata/rule_tags/rhs-inferred-property-second-cell.json
@@ -1,0 +1,14 @@
+{
+  "schema": "ps-static-analysis-testdata-v1",
+  "ruleTag": [
+    {
+      "line": 76,
+      "text": "right [ player | sibling1_or_sibling2 ] -> [ player | sibling1_or_sibling2 ]",
+      "tags": {
+        "objects_matched": ["Player", "Sibling1", "Sibling2"],
+        "objects_written": [],
+        "objects_erased": []
+      }
+    }
+  ]
+}

--- a/src/tests/static_analysis_testdata/rule_tags/rhs-inferred-property-second-cell.txt
+++ b/src/tests/static_analysis_testdata/rule_tags/rhs-inferred-property-second-cell.txt
@@ -1,0 +1,88 @@
+title Static Analysis Rule Tag RHS Inferred Property Second Cell
+
+========
+OBJECTS
+========
+
+Background
+black
+
+Target
+yellow
+
+Player
+white
+
+Wall
+brown
+
+Crate
+orange
+
+Alpha
+red
+
+Beta
+blue
+
+Gamma
+green
+
+Orphan1
+lightblue
+
+Sibling1
+purple
+
+Sibling2
+pink
+
+========
+LEGEND
+========
+
+. = Background
+T = Target
+P = Player
+# = Wall
+C = Crate
+A = Alpha
+B = Beta
+G = Gamma
+O = Orphan1
+X = Sibling1
+Y = Sibling2
+Sibling1_or_Sibling2 = Sibling1 or Sibling2
+
+========
+SOUNDS
+========
+
+================
+COLLISIONLAYERS
+================
+
+Background
+Target
+Player, Wall, Crate
+Alpha, Beta, Gamma
+Orphan1
+Sibling1, Sibling2
+
+=====
+RULES
+=====
+
+right [ player | sibling1_or_sibling2 ] -> [ player | sibling1_or_sibling2 ]
+
+=============
+WINCONDITIONS
+=============
+
+Some Player
+
+======
+LEVELS
+======
+
+TP#CABGOXY

--- a/src/tests/static_analysis_testdata/rule_tags/rhs-inferred-property-to-sibling1.json
+++ b/src/tests/static_analysis_testdata/rule_tags/rhs-inferred-property-to-sibling1.json
@@ -1,0 +1,14 @@
+{
+  "schema": "ps-static-analysis-testdata-v1",
+  "ruleTag": [
+    {
+      "line": 76,
+      "text": "[ sibling1_or_sibling2 ] -> [ sibling1 ]",
+      "tags": {
+        "objects_matched": ["Sibling1", "Sibling2"],
+        "objects_written": ["Sibling1"],
+        "objects_erased": ["Sibling2"]
+      }
+    }
+  ]
+}

--- a/src/tests/static_analysis_testdata/rule_tags/rhs-inferred-property-to-sibling1.txt
+++ b/src/tests/static_analysis_testdata/rule_tags/rhs-inferred-property-to-sibling1.txt
@@ -1,0 +1,88 @@
+title Static Analysis Rule Tag RHS Inferred Property To Sibling1
+
+========
+OBJECTS
+========
+
+Background
+black
+
+Target
+yellow
+
+Player
+white
+
+Wall
+brown
+
+Crate
+orange
+
+Alpha
+red
+
+Beta
+blue
+
+Gamma
+green
+
+Orphan1
+lightblue
+
+Sibling1
+purple
+
+Sibling2
+pink
+
+========
+LEGEND
+========
+
+. = Background
+T = Target
+P = Player
+# = Wall
+C = Crate
+A = Alpha
+B = Beta
+G = Gamma
+O = Orphan1
+X = Sibling1
+Y = Sibling2
+Sibling1_or_Sibling2 = Sibling1 or Sibling2
+
+========
+SOUNDS
+========
+
+================
+COLLISIONLAYERS
+================
+
+Background
+Target
+Player, Wall, Crate
+Alpha, Beta, Gamma
+Orphan1
+Sibling1, Sibling2
+
+=====
+RULES
+=====
+
+[ sibling1_or_sibling2 ] -> [ sibling1 ]
+
+=============
+WINCONDITIONS
+=============
+
+Some Player
+
+======
+LEVELS
+======
+
+TP#CABGOXY

--- a/src/tests/static_analysis_testdata/rule_tags/rhs-inferred-property-two-cells.json
+++ b/src/tests/static_analysis_testdata/rule_tags/rhs-inferred-property-two-cells.json
@@ -1,0 +1,14 @@
+{
+  "schema": "ps-static-analysis-testdata-v1",
+  "ruleTag": [
+    {
+      "line": 76,
+      "text": "right [ sibling1_or_sibling2 | sibling1_or_sibling2 ] -> [ sibling1_or_sibling2 | sibling1_or_sibling2 ]",
+      "tags": {
+        "objects_matched": ["Sibling1", "Sibling2"],
+        "objects_written": [],
+        "objects_erased": []
+      }
+    }
+  ]
+}

--- a/src/tests/static_analysis_testdata/rule_tags/rhs-inferred-property-two-cells.txt
+++ b/src/tests/static_analysis_testdata/rule_tags/rhs-inferred-property-two-cells.txt
@@ -1,0 +1,88 @@
+title Static Analysis Rule Tag RHS Inferred Property Two Cells
+
+========
+OBJECTS
+========
+
+Background
+black
+
+Target
+yellow
+
+Player
+white
+
+Wall
+brown
+
+Crate
+orange
+
+Alpha
+red
+
+Beta
+blue
+
+Gamma
+green
+
+Orphan1
+lightblue
+
+Sibling1
+purple
+
+Sibling2
+pink
+
+========
+LEGEND
+========
+
+. = Background
+T = Target
+P = Player
+# = Wall
+C = Crate
+A = Alpha
+B = Beta
+G = Gamma
+O = Orphan1
+X = Sibling1
+Y = Sibling2
+Sibling1_or_Sibling2 = Sibling1 or Sibling2
+
+========
+SOUNDS
+========
+
+================
+COLLISIONLAYERS
+================
+
+Background
+Target
+Player, Wall, Crate
+Alpha, Beta, Gamma
+Orphan1
+Sibling1, Sibling2
+
+=====
+RULES
+=====
+
+right [ sibling1_or_sibling2 | sibling1_or_sibling2 ] -> [ sibling1_or_sibling2 | sibling1_or_sibling2 ]
+
+=============
+WINCONDITIONS
+=============
+
+Some Player
+
+======
+LEVELS
+======
+
+TP#CABGOXY

--- a/src/tests/static_analysis_testdata/rule_tags/rhs-inferred-property-with-movement.json
+++ b/src/tests/static_analysis_testdata/rule_tags/rhs-inferred-property-with-movement.json
@@ -1,0 +1,18 @@
+{
+  "schema": "ps-static-analysis-testdata-v1",
+  "ruleTag": [
+    {
+      "line": 76,
+      "text": "[ right sibling1_or_sibling2 ] -> [ left sibling1_or_sibling2 ]",
+      "tags": {
+        "objects_matched": ["Sibling1", "Sibling2"],
+        "objects_written": [],
+        "objects_erased": [],
+        "movements_required": [],
+        "movements_matched": ["Sibling1:right", "Sibling2:right"],
+        "movements_written": ["Sibling1:left", "Sibling2:left"],
+        "movements_removed": ["Sibling1:right", "Sibling2:right"]
+      }
+    }
+  ]
+}

--- a/src/tests/static_analysis_testdata/rule_tags/rhs-inferred-property-with-movement.txt
+++ b/src/tests/static_analysis_testdata/rule_tags/rhs-inferred-property-with-movement.txt
@@ -1,0 +1,88 @@
+title Static Analysis Rule Tag RHS Inferred Property With Movement
+
+========
+OBJECTS
+========
+
+Background
+black
+
+Target
+yellow
+
+Player
+white
+
+Wall
+brown
+
+Crate
+orange
+
+Alpha
+red
+
+Beta
+blue
+
+Gamma
+green
+
+Orphan1
+lightblue
+
+Sibling1
+purple
+
+Sibling2
+pink
+
+========
+LEGEND
+========
+
+. = Background
+T = Target
+P = Player
+# = Wall
+C = Crate
+A = Alpha
+B = Beta
+G = Gamma
+O = Orphan1
+X = Sibling1
+Y = Sibling2
+Sibling1_or_Sibling2 = Sibling1 or Sibling2
+
+========
+SOUNDS
+========
+
+================
+COLLISIONLAYERS
+================
+
+Background
+Target
+Player, Wall, Crate
+Alpha, Beta, Gamma
+Orphan1
+Sibling1, Sibling2
+
+=====
+RULES
+=====
+
+[ right sibling1_or_sibling2 ] -> [ left sibling1_or_sibling2 ]
+
+=============
+WINCONDITIONS
+=============
+
+Some Player
+
+======
+LEVELS
+======
+
+TP#CABGOXY

--- a/src/tests/static_analysis_testdata/rule_tags/rhs-inferred-two-properties.json
+++ b/src/tests/static_analysis_testdata/rule_tags/rhs-inferred-two-properties.json
@@ -1,0 +1,14 @@
+{
+  "schema": "ps-static-analysis-testdata-v1",
+  "ruleTag": [
+    {
+      "line": 77,
+      "text": "[ alpha_or_beta sibling1_or_sibling2 ] -> [ alpha_or_beta sibling1_or_sibling2 ]",
+      "tags": {
+        "objects_matched": ["Alpha", "Beta", "Sibling1", "Sibling2"],
+        "objects_written": [],
+        "objects_erased": []
+      }
+    }
+  ]
+}

--- a/src/tests/static_analysis_testdata/rule_tags/rhs-inferred-two-properties.txt
+++ b/src/tests/static_analysis_testdata/rule_tags/rhs-inferred-two-properties.txt
@@ -1,0 +1,89 @@
+title Static Analysis Rule Tag RHS Inferred Two Properties
+
+========
+OBJECTS
+========
+
+Background
+black
+
+Target
+yellow
+
+Player
+white
+
+Wall
+brown
+
+Crate
+orange
+
+Alpha
+red
+
+Beta
+blue
+
+Gamma
+green
+
+Orphan1
+lightblue
+
+Sibling1
+purple
+
+Sibling2
+pink
+
+========
+LEGEND
+========
+
+. = Background
+T = Target
+P = Player
+# = Wall
+C = Crate
+A = Alpha
+B = Beta
+G = Gamma
+O = Orphan1
+X = Sibling1
+Y = Sibling2
+Sibling1_or_Sibling2 = Sibling1 or Sibling2
+Alpha_or_Beta = Alpha or Beta
+
+========
+SOUNDS
+========
+
+================
+COLLISIONLAYERS
+================
+
+Background
+Target
+Player, Wall, Crate
+Alpha, Beta, Gamma
+Orphan1
+Sibling1, Sibling2
+
+=====
+RULES
+=====
+
+[ alpha_or_beta sibling1_or_sibling2 ] -> [ alpha_or_beta sibling1_or_sibling2 ]
+
+=============
+WINCONDITIONS
+=============
+
+Some Player
+
+======
+LEVELS
+======
+
+TP#CABGOXY


### PR DESCRIPTION
Two batches of static-analyser work on this branch.

## Part 1: Rule tag fixtures

15 new fixture pairs under `static_analysis_testdata/rule_tags/` covering scenarios not previously exercised:

**Type inference (property on both LHS and RHS)**
- `rhs-inferred-property-deleted` — property erased on RHS
- `rhs-inferred-property-to-sibling1` — property narrowed to a concrete sibling
- `rhs-inferred-property-second-cell` — property in second cell of a multicell rule
- `rhs-inferred-property-multilayer` — property alongside an object on a different layer
- `rhs-inferred-property-layer-drop` — one layer dropped on RHS, other inferred
- `rhs-inferred-property-with-movement` — movement tag flipped on an inferred property
- `rhs-inferred-property-replaced-by-orphan` — property replaced by an unrelated object
- `rhs-inferred-property-two-cells` — same property in both cells of a multicell rule
- `rhs-inferred-two-properties` — two independent properties inferred in the same cell
- `rhs-inferred-property-absent-guard` — inferred property with an absence guard

**Movement patterns**
- `movement-push-chain` — moving player pushes crate (required + written movement)
- `movement-action-write` — action movement cleared, stationary written to two objects
- `movement-action-on-property` — action movement on an OR-property
- `movement-ellipsis` — ellipsis cell is transparent to movement analysis

**Absence / conditional write**
- `rhs-absent-adjacent-cell` — adjacent cell absence guard with fresh object write

## Part 2: program_flow wake graph

New top-level fact `program_flow` plus fixture coverage that doubles as the validation suite for the underlying `ruleMayEnableRule` predicate (which previously had no test coverage).

**Analyser** (`src/tests/ps_static_analysis.js`)
- Extracted the pairwise edge loop from `deriveRulegroupFlowFacts` into a shared `wakeEdgesForRules` helper. The within-group `rulegroup_flow` output is preserved byte-identically.
- Added `deriveProgramFlowFacts` producing one `program_flow` fact per program with `wake_edges` (every ordered (R1, R2) pair where R1's writes may enable R2's LHS, no scope segmentation), `again_rules` (rules that force a tick restart), and `tick_restart_possible`.
- Documented consumer rule: effective wake set = `wake_edges ∪ (again_rules × rule_ids)`.

**Runner** (`src/tests/static_analysis_testdata_runner.js`)
- New `program_flow/` fixture pipeline mirroring the rule_tags pattern: edges keyed by `(line, text)`, auto-generated JSON when missing, sorted comparison.
- Extended `renderRuleText` to emit the `late ` prefix and trailing rule commands so `late` and `again`-bearing rules pass the source-vs-canonical idempotency check.
- Added `factFamilies` validation in `loadClaimDescriptions`.

**Fixtures** (9, hand-audited)
- `wake-object-presence`, `wake-object-absence`
- `wake-movement-exact`, `wake-movement-randomdir`
- `wake-property-write`, `wake-self-loop`
- `wake-again`, `wake-cross-section`, `wake-none`

**Note worth following up:** `moving` on LHS desugars into specific cardinals at compile time, so the cardinal-to-`moving` subsumption branch in `movementWriteMayEnableRead` (line 1473) may be unreachable from normal source. Worth confirming before relying on it.

## Verification

- `node src/tests/run_tests_node.js` — 742/742 passing
- `node src/tests/static_analysis_testdata_runner.js` — passing
- Spot-checks on real games from the solver corpus (`8 happy snakes`: 38 rules / 163 edges; `Bicycle-Kick Football`: 30 rules / 65 edges / 12 again rules) showed sane numbers.