### PR TITLE
Static analyser: program flow wake graph + win condition tags

### DIFF
--- a/src/tests/ps_static_analysis.js
+++ b/src/tests/ps_static_analysis.js
@@ -475,6 +475,7 @@ function emptyFacts() {
         count_layer_invariants: [],
         transient_boundary: [],
         rulegroup_flow: [],
+        program_flow: [],
     };
 }
 
@@ -1490,6 +1491,21 @@ function ruleMayEnableRule(writes, reads) {
     return reasons;
 }
 
+function wakeEdgesForRules(psTagged, rules) {
+    const reads = new Map(rules.map(rule => [rule.id, ruleFlowReads(rule)]));
+    const writes = new Map(rules.map(rule => [rule.id, ruleFlowWrites(psTagged, rule)]));
+    const edges = [];
+    for (const fromRule of rules) {
+        const fromWrites = writes.get(fromRule.id);
+        for (const toRule of rules) {
+            const reasons = ruleMayEnableRule(fromWrites, reads.get(toRule.id));
+            if (reasons.length === 0) continue;
+            edges.push({ from: fromRule.id, to: toRule.id, reasons });
+        }
+    }
+    return edges;
+}
+
 function connectedComponents(ruleIds, edges) {
     const parent = new Map(ruleIds.map(id => [id, id]));
     function find(id) {
@@ -1524,21 +1540,12 @@ function deriveRulegroupFlowFacts(psTagged) {
         for (const group of section.groups) {
             if (group.rules.length <= 1) continue;
             const ruleIds = group.rules.map(rule => rule.id);
-            const readsByRule = new Map(group.rules.map(rule => [rule.id, ruleFlowReads(rule)]));
-            const writesByRule = new Map(group.rules.map(rule => [rule.id, ruleFlowWrites(psTagged, rule)]));
-            const interactionEdges = [];
+            const indexById = new Map(group.rules.map((rule, index) => [rule.id, index]));
+            const interactionEdges = wakeEdgesForRules(psTagged, group.rules);
             const rerunMasks = Object.fromEntries(ruleIds.map(id => [id, []]));
-            for (let fromIndex = 0; fromIndex < group.rules.length; fromIndex++) {
-                const fromRule = group.rules[fromIndex];
-                const writes = writesByRule.get(fromRule.id);
-                for (let toIndex = 0; toIndex < group.rules.length; toIndex++) {
-                    const toRule = group.rules[toIndex];
-                    const reasons = ruleMayEnableRule(writes, readsByRule.get(toRule.id));
-                    if (reasons.length === 0) continue;
-                    interactionEdges.push({ from: fromRule.id, to: toRule.id, reasons });
-                    if (toIndex <= fromIndex) {
-                        rerunMasks[fromRule.id].push(toRule.id);
-                    }
+            for (const edge of interactionEdges) {
+                if (indexById.get(edge.to) <= indexById.get(edge.from)) {
+                    rerunMasks[edge.from].push(edge.to);
                 }
             }
             for (const ruleId of ruleIds) {
@@ -1569,6 +1576,25 @@ function deriveRulegroupFlowFacts(psTagged) {
     return results;
 }
 
+function deriveProgramFlowFacts(psTagged) {
+    const entries = allRuleEntries(psTagged);
+    const rules = entries.map(entry => entry.rule);
+    const ruleIds = rules.map(rule => rule.id);
+    const wakeEdges = wakeEdgesForRules(psTagged, rules);
+    const againRules = rules.filter(rule => rule.tags.has_again).map(rule => rule.id);
+    return [fact('program_flow', 'program_flow', 'proved', {
+        subjects: { rules: ruleIds },
+        value: {
+            rule_ids: ruleIds,
+            wake_edges: wakeEdges,
+            again_rules: uniqueSorted(againRules),
+            tick_restart_possible: againRules.length > 0,
+        },
+        proof: ['direct_wake_enablement', 'again_rules_listed'],
+        evidence: ruleIds,
+    })];
+}
+
 function deriveFacts(psTagged) {
     return {
         mergeability: deriveMergeabilityFacts(psTagged),
@@ -1576,6 +1602,7 @@ function deriveFacts(psTagged) {
         count_layer_invariants: deriveCountLayerInvariantFacts(psTagged),
         transient_boundary: deriveTransientBoundaryFacts(psTagged),
         rulegroup_flow: deriveRulegroupFlowFacts(psTagged),
+        program_flow: deriveProgramFlowFacts(psTagged),
     };
 }
 

--- a/src/tests/ps_static_analysis.js
+++ b/src/tests/ps_static_analysis.js
@@ -110,9 +110,9 @@ function buildWinconditions(state) {
             targets,
             tags: {
                 plain: plainCondition,
-                objects_matched: uniqueSorted(subjects.concat(targets)),
+                objects_matched: isNo ? uniqueSorted(subjects) : uniqueSorted(subjects.concat(targets)),
                 subjects_matched: isNo ? [] : uniqueSorted(subjects),
-                targets_matched: uniqueSorted(targets),
+                targets_matched: isNo ? [] : uniqueSorted(targets),
                 object_absences_matched: isNo ? uniqueSorted(subjects) : [],
             },
         };

--- a/src/tests/ps_static_analysis.js
+++ b/src/tests/ps_static_analysis.js
@@ -99,12 +99,22 @@ function buildWinconditions(state) {
     return Array.from(state.winconditions, (condition, index) => {
         const targetNames = condition[2] ? objectInternalNamesFromMask(state, condition[2]) : [];
         const plainCondition = targetNames.length === objectCount;
+        const subjects = objectNamesFromMask(state, condition[1]);
+        const targets = plainCondition ? [] : targetNames.map(name => displayName(state, name));
+        const isNo = condition[0] === -1;
         return {
             id: `win_${index}`,
             quantifier: condition[0],
-            subjects: objectNamesFromMask(state, condition[1]),
-            targets: plainCondition ? [] : targetNames.map(name => displayName(state, name)),
-            tags: { plain: plainCondition },
+            source_line: condition[3],
+            subjects,
+            targets,
+            tags: {
+                plain: plainCondition,
+                objects_matched: uniqueSorted(subjects.concat(targets)),
+                subjects_matched: isNo ? [] : uniqueSorted(subjects),
+                targets_matched: uniqueSorted(targets),
+                object_absences_matched: isNo ? uniqueSorted(subjects) : [],
+            },
         };
     });
 }

--- a/src/tests/static_analysis_claim_descriptions.json
+++ b/src/tests/static_analysis_claim_descriptions.json
@@ -86,7 +86,7 @@
     {
       "name": "objects_matched",
       "description": "Concrete objects whose presence or absence is read by this win condition.",
-      "specification": "A win condition has objects_matched entries for every concrete object referenced in either the subjects mask or the targets mask, after resolving properties to concrete names. This is the conservative union: an object appears here whenever its distribution on the board could affect the win outcome, regardless of quantifier. objects_matched = subjects_matched ∪ targets_matched ∪ object_absences_matched."
+      "specification": "A win condition has objects_matched entries for every concrete object that contributes to the win read-set, after resolving properties to concrete names. For SOME and ALL this is subjects ∪ targets. For NO this is the subjects mask only (the location qualifier Y in 'No X on Y' is not considered a read). objects_matched = subjects_matched ∪ targets_matched ∪ object_absences_matched."
     },
     {
       "name": "subjects_matched",
@@ -96,7 +96,7 @@
     {
       "name": "targets_matched",
       "description": "Concrete objects in the targets mask (the 'on X' part of a win condition).",
-      "specification": "A win condition has targets_matched entries for the concrete objects in the targets mask, after resolving properties to concrete names. The targets mask is the optional second mask in a two-mask win condition of the form 'Some X on Y'. When there is no targets mask, targets_matched is empty. The targets mask applies to all quantifiers."
+      "specification": "A win condition has targets_matched entries for the concrete objects in the targets mask, after resolving properties to concrete names. The targets mask is the optional second mask in a two-mask win condition of the form 'Some X on Y' or 'All X on Y'. When there is no targets mask, or when the quantifier is NO, targets_matched is empty. Under NO, the location qualifier Y is not considered a read for wake-edge purposes."
     },
     {
       "name": "object_absences_matched",

--- a/src/tests/static_analysis_claim_descriptions.json
+++ b/src/tests/static_analysis_claim_descriptions.json
@@ -81,5 +81,27 @@
       "description": "Pairwise wake graph: which rules may, when applied, create a new match for which other rules.",
       "specification": "The program_flow fact lists, for the whole program, every ordered rule pair (R1, R2) where R1's RHS writes may enable a new match for R2's LHS. An edge is emitted whenever R1's writes intersect R2's reads in any of: object presence (writing an object R2 requires present), object absence (erasing an object R2 requires absent), or movement (writing an object:movement R2 reads, including the cardinal-to-moving subsumption). Edges are listed for all ordered pairs across all rule sections without scope segmentation; self-edges (R -> R) are kept when present. The again_rules field lists every rule whose firing semantically forces a tick restart (rules whose summary commands include `again`). Consumers that want the worst-case wake set should take the union of wake_edges with again_rules x rule_ids; this expansion is intentionally not materialised in the fact."
     }
+  ],
+  "winConditionTags": [
+    {
+      "name": "objects_matched",
+      "description": "Concrete objects whose presence or absence is read by this win condition.",
+      "specification": "A win condition has objects_matched entries for every concrete object referenced in either the subjects mask or the targets mask, after resolving properties to concrete names. This is the conservative union: an object appears here whenever its distribution on the board could affect the win outcome, regardless of quantifier. objects_matched = subjects_matched ∪ targets_matched ∪ object_absences_matched."
+    },
+    {
+      "name": "subjects_matched",
+      "description": "Concrete objects in the subjects mask when the quantifier is SOME or ALL.",
+      "specification": "A win condition has subjects_matched entries for the concrete objects in the subjects mask when the quantifier is SOME (0) or ALL (1). When the quantifier is NO (-1) the subjects represent an absence requirement; in that case subjects_matched is empty and the same concrete names appear in object_absences_matched instead."
+    },
+    {
+      "name": "targets_matched",
+      "description": "Concrete objects in the targets mask (the 'on X' part of a win condition).",
+      "specification": "A win condition has targets_matched entries for the concrete objects in the targets mask, after resolving properties to concrete names. The targets mask is the optional second mask in a two-mask win condition of the form 'Some X on Y'. When there is no targets mask, targets_matched is empty. The targets mask applies to all quantifiers."
+    },
+    {
+      "name": "object_absences_matched",
+      "description": "Concrete objects whose absence is the win signal when the quantifier is NO.",
+      "specification": "A win condition has object_absences_matched entries for the concrete objects in the subjects mask when the quantifier is NO (-1). Under NO, the win condition is satisfied when none of those objects are present, so the subjects mask represents an absence read rather than a presence read. When the quantifier is SOME or ALL, object_absences_matched is empty."
+    }
   ]
 }

--- a/src/tests/static_analysis_claim_descriptions.json
+++ b/src/tests/static_analysis_claim_descriptions.json
@@ -74,5 +74,12 @@
       "description": "Concrete object movements no longer present after the rule RHS.",
       "specification": "A rule has movements_removed entries of the form Object:movement for concrete LHS movement matches that are not preserved by an identical RHS movement match for the same object in the corresponding RHS cell. This includes direction changes, movement clears, object relocation, object deletion, and action matches consumed by an RHS movement write."
     }
+  ],
+  "factFamilies": [
+    {
+      "name": "program_flow",
+      "description": "Pairwise wake graph: which rules may, when applied, create a new match for which other rules.",
+      "specification": "The program_flow fact lists, for the whole program, every ordered rule pair (R1, R2) where R1's RHS writes may enable a new match for R2's LHS. An edge is emitted whenever R1's writes intersect R2's reads in any of: object presence (writing an object R2 requires present), object absence (erasing an object R2 requires absent), or movement (writing an object:movement R2 reads, including the cardinal-to-moving subsumption). Edges are listed for all ordered pairs across all rule sections without scope segmentation; self-edges (R -> R) are kept when present. The again_rules field lists every rule whose firing semantically forces a tick restart (rules whose summary commands include `again`). Consumers that want the worst-case wake set should take the union of wake_edges with again_rules x rule_ids; this expansion is intentionally not materialised in the fact."
+    }
   ]
 }

--- a/src/tests/static_analysis_testdata/README.md
+++ b/src/tests/static_analysis_testdata/README.md
@@ -116,6 +116,26 @@ to report an object as matched, absent, written, or erased.
 Like rule-tag tests, edges identify rules by `line` plus trimmed source `text`,
 so program-flow sources should also use compiler-idempotent rule text.
 
+## Adding A Win-Condition-Tag Test
+
+1. Add a small whole-source `.txt` file under `wincondition_tags/`.
+2. Run `make static_analysis_tests` (or `node src/tests/static_analysis_testdata_runner.js`).
+3. The runner will create the missing matching `.json` file. Each entry under
+   `winConditionTag` lists one win condition identified by `line` plus trimmed
+   source `text`, with four tag arrays:
+   - `objects_matched` — union of all concrete objects referenced (subjects ∪ targets).
+   - `subjects_matched` — concrete subjects when quantifier is SOME or ALL; empty for NO.
+   - `targets_matched` — concrete targets from the optional `on Y` part; empty when absent.
+   - `object_absences_matched` — concrete subjects when quantifier is NO; empty for SOME/ALL.
+4. Read the generated JSON and confirm that each tag array reflects the correct
+   expansion of the source win condition.
+
+Win-condition-tag sources must use compiler-idempotent rule text (same constraint
+as rule-tag tests). Fixtures should follow the same object-naming conventions
+(Background / Target / Player / Wall / Crate / Alpha / Beta / Gamma / Orphan1 /
+Sibling1 / Sibling2) so readers can understand the collision-layer structure
+without re-reading the entire source file.
+
 ## Review Policy
 
 Auto-generated or mechanically regenerated expectation JSON is a proposal, not

--- a/src/tests/static_analysis_testdata/README.md
+++ b/src/tests/static_analysis_testdata/README.md
@@ -101,6 +101,21 @@ Avoid names that describe the expected analyzer output. The object names should
 describe the specimen's layer/property structure, not whether a tag is expected
 to report an object as matched, absent, written, or erased.
 
+## Adding A Program-Flow Test
+
+1. Add a small whole-source `.txt` file under `program_flow/`.
+2. Run `make static_analysis_tests` (or `node src/tests/static_analysis_testdata_runner.js`).
+3. The runner will create the missing matching `.json` file. Each entry under
+   `wakeEdges` lists one ordered (from, to) rule pair where firing `from`
+   may enable a new match for `to`, with the reasons that triggered the edge
+   (`object_presence`, `object_absence`, or `movement`). Each entry under
+   `againRules` lists a rule whose firing semantically forces a tick restart.
+4. Read the generated JSON and confirm by hand that every edge corresponds to
+   an actual write-on-from / read-on-to relationship in the source.
+
+Like rule-tag tests, edges identify rules by `line` plus trimmed source `text`,
+so program-flow sources should also use compiler-idempotent rule text.
+
 ## Review Policy
 
 Auto-generated or mechanically regenerated expectation JSON is a proposal, not

--- a/src/tests/static_analysis_testdata/program_flow/wake-again.json
+++ b/src/tests/static_analysis_testdata/program_flow/wake-again.json
@@ -1,0 +1,10 @@
+{
+  "schema": "ps-static-analysis-testdata-v1",
+  "wakeEdges": [],
+  "againRules": [
+    {
+      "line": 53,
+      "text": "[ player no orphan1 ] -> [ stationary player orphan1 ] again"
+    }
+  ]
+}

--- a/src/tests/static_analysis_testdata/program_flow/wake-again.txt
+++ b/src/tests/static_analysis_testdata/program_flow/wake-again.txt
@@ -1,0 +1,65 @@
+title Static Analysis Program Flow Wake Again
+
+========
+OBJECTS
+========
+
+Background
+black
+
+Target
+yellow
+
+Player
+white
+
+Wall
+brown
+
+Crate
+orange
+
+Orphan1
+lightblue
+
+========
+LEGEND
+========
+
+. = Background
+T = Target
+P = Player
+# = Wall
+C = Crate
+O = Orphan1
+
+========
+SOUNDS
+========
+
+================
+COLLISIONLAYERS
+================
+
+Background
+Target
+Player, Wall, Crate
+Orphan1
+
+=====
+RULES
+=====
+
+[ player no orphan1 ] -> [ stationary player orphan1 ] again
+
+=============
+WINCONDITIONS
+=============
+
+Some Player
+
+======
+LEVELS
+======
+
+P..

--- a/src/tests/static_analysis_testdata/program_flow/wake-cross-section.json
+++ b/src/tests/static_analysis_testdata/program_flow/wake-cross-section.json
@@ -1,0 +1,13 @@
+{
+  "schema": "ps-static-analysis-testdata-v1",
+  "wakeEdges": [
+    {
+      "from_line": 61,
+      "from_text": "[ player ] -> [ stationary alpha ]",
+      "to_line": 62,
+      "to_text": "late [ alpha ] -> [ ]",
+      "reasons": ["object_presence"]
+    }
+  ],
+  "againRules": []
+}

--- a/src/tests/static_analysis_testdata/program_flow/wake-cross-section.txt
+++ b/src/tests/static_analysis_testdata/program_flow/wake-cross-section.txt
@@ -1,0 +1,74 @@
+title Static Analysis Program Flow Wake Cross Section
+
+========
+OBJECTS
+========
+
+Background
+black
+
+Target
+yellow
+
+Player
+white
+
+Wall
+brown
+
+Crate
+orange
+
+Alpha
+red
+
+Beta
+blue
+
+Gamma
+green
+
+========
+LEGEND
+========
+
+. = Background
+T = Target
+P = Player
+# = Wall
+C = Crate
+A = Alpha
+B = Beta
+G = Gamma
+
+========
+SOUNDS
+========
+
+================
+COLLISIONLAYERS
+================
+
+Background
+Target
+Player, Wall, Crate
+Alpha, Beta, Gamma
+
+=====
+RULES
+=====
+
+[ player ] -> [ stationary alpha ]
+late [ alpha ] -> [ ]
+
+=============
+WINCONDITIONS
+=============
+
+Some Player
+
+======
+LEVELS
+======
+
+P..

--- a/src/tests/static_analysis_testdata/program_flow/wake-movement-exact.json
+++ b/src/tests/static_analysis_testdata/program_flow/wake-movement-exact.json
@@ -1,0 +1,13 @@
+{
+  "schema": "ps-static-analysis-testdata-v1",
+  "wakeEdges": [
+    {
+      "from_line": 48,
+      "from_text": "right [ player | crate ] -> [ player | right crate ]",
+      "to_line": 49,
+      "to_text": "[ right crate ] -> [ stationary crate ]",
+      "reasons": ["movement"]
+    }
+  ],
+  "againRules": []
+}

--- a/src/tests/static_analysis_testdata/program_flow/wake-movement-exact.txt
+++ b/src/tests/static_analysis_testdata/program_flow/wake-movement-exact.txt
@@ -1,0 +1,61 @@
+title Static Analysis Program Flow Wake Movement Exact
+
+========
+OBJECTS
+========
+
+Background
+black
+
+Target
+yellow
+
+Player
+white
+
+Wall
+brown
+
+Crate
+orange
+
+========
+LEGEND
+========
+
+. = Background
+T = Target
+P = Player
+# = Wall
+C = Crate
+
+========
+SOUNDS
+========
+
+================
+COLLISIONLAYERS
+================
+
+Background
+Target
+Player, Wall, Crate
+
+=====
+RULES
+=====
+
+right [ player | crate ] -> [ player | right crate ]
+[ right crate ] -> [ stationary crate ]
+
+=============
+WINCONDITIONS
+=============
+
+Some Player
+
+======
+LEVELS
+======
+
+PC.

--- a/src/tests/static_analysis_testdata/program_flow/wake-movement-randomdir.json
+++ b/src/tests/static_analysis_testdata/program_flow/wake-movement-randomdir.json
@@ -1,0 +1,13 @@
+{
+  "schema": "ps-static-analysis-testdata-v1",
+  "wakeEdges": [
+    {
+      "from_line": 48,
+      "from_text": "[ player ] -> [ randomdir player ]",
+      "to_line": 49,
+      "to_text": "[ right player ] -> [ stationary player ]",
+      "reasons": ["movement"]
+    }
+  ],
+  "againRules": []
+}

--- a/src/tests/static_analysis_testdata/program_flow/wake-movement-randomdir.txt
+++ b/src/tests/static_analysis_testdata/program_flow/wake-movement-randomdir.txt
@@ -1,0 +1,61 @@
+title Static Analysis Program Flow Wake Movement Randomdir
+
+========
+OBJECTS
+========
+
+Background
+black
+
+Target
+yellow
+
+Player
+white
+
+Wall
+brown
+
+Crate
+orange
+
+========
+LEGEND
+========
+
+. = Background
+T = Target
+P = Player
+# = Wall
+C = Crate
+
+========
+SOUNDS
+========
+
+================
+COLLISIONLAYERS
+================
+
+Background
+Target
+Player, Wall, Crate
+
+=====
+RULES
+=====
+
+[ player ] -> [ randomdir player ]
+[ right player ] -> [ stationary player ]
+
+=============
+WINCONDITIONS
+=============
+
+Some Player
+
+======
+LEVELS
+======
+
+P..

--- a/src/tests/static_analysis_testdata/program_flow/wake-none.json
+++ b/src/tests/static_analysis_testdata/program_flow/wake-none.json
@@ -1,0 +1,5 @@
+{
+  "schema": "ps-static-analysis-testdata-v1",
+  "wakeEdges": [],
+  "againRules": []
+}

--- a/src/tests/static_analysis_testdata/program_flow/wake-none.txt
+++ b/src/tests/static_analysis_testdata/program_flow/wake-none.txt
@@ -1,0 +1,66 @@
+title Static Analysis Program Flow Wake None
+
+========
+OBJECTS
+========
+
+Background
+black
+
+Target
+yellow
+
+Player
+white
+
+Wall
+brown
+
+Crate
+orange
+
+Orphan1
+lightblue
+
+========
+LEGEND
+========
+
+. = Background
+T = Target
+P = Player
+# = Wall
+C = Crate
+O = Orphan1
+
+========
+SOUNDS
+========
+
+================
+COLLISIONLAYERS
+================
+
+Background
+Target
+Player, Wall, Crate
+Orphan1
+
+=====
+RULES
+=====
+
+[ orphan1 ] -> [ ]
+[ player ] -> [ wall ]
+
+=============
+WINCONDITIONS
+=============
+
+Some Player
+
+======
+LEVELS
+======
+
+PO.

--- a/src/tests/static_analysis_testdata/program_flow/wake-object-absence.json
+++ b/src/tests/static_analysis_testdata/program_flow/wake-object-absence.json
@@ -1,0 +1,13 @@
+{
+  "schema": "ps-static-analysis-testdata-v1",
+  "wakeEdges": [
+    {
+      "from_line": 53,
+      "from_text": "[ orphan1 ] -> [ ]",
+      "to_line": 54,
+      "to_text": "[ player no orphan1 ] -> [ stationary player ]",
+      "reasons": ["object_absence"]
+    }
+  ],
+  "againRules": []
+}

--- a/src/tests/static_analysis_testdata/program_flow/wake-object-absence.txt
+++ b/src/tests/static_analysis_testdata/program_flow/wake-object-absence.txt
@@ -1,0 +1,66 @@
+title Static Analysis Program Flow Wake Object Absence
+
+========
+OBJECTS
+========
+
+Background
+black
+
+Target
+yellow
+
+Player
+white
+
+Wall
+brown
+
+Crate
+orange
+
+Orphan1
+lightblue
+
+========
+LEGEND
+========
+
+. = Background
+T = Target
+P = Player
+# = Wall
+C = Crate
+O = Orphan1
+
+========
+SOUNDS
+========
+
+================
+COLLISIONLAYERS
+================
+
+Background
+Target
+Player, Wall, Crate
+Orphan1
+
+=====
+RULES
+=====
+
+[ orphan1 ] -> [ ]
+[ player no orphan1 ] -> [ stationary player ]
+
+=============
+WINCONDITIONS
+=============
+
+Some Player
+
+======
+LEVELS
+======
+
+P.O

--- a/src/tests/static_analysis_testdata/program_flow/wake-object-presence.json
+++ b/src/tests/static_analysis_testdata/program_flow/wake-object-presence.json
@@ -1,0 +1,13 @@
+{
+  "schema": "ps-static-analysis-testdata-v1",
+  "wakeEdges": [
+    {
+      "from_line": 48,
+      "from_text": "[ player ] -> [ crate ]",
+      "to_line": 49,
+      "to_text": "[ crate ] -> [ stationary target ]",
+      "reasons": ["object_presence"]
+    }
+  ],
+  "againRules": []
+}

--- a/src/tests/static_analysis_testdata/program_flow/wake-object-presence.txt
+++ b/src/tests/static_analysis_testdata/program_flow/wake-object-presence.txt
@@ -1,0 +1,61 @@
+title Static Analysis Program Flow Wake Object Presence
+
+========
+OBJECTS
+========
+
+Background
+black
+
+Target
+yellow
+
+Player
+white
+
+Wall
+brown
+
+Crate
+orange
+
+========
+LEGEND
+========
+
+. = Background
+T = Target
+P = Player
+# = Wall
+C = Crate
+
+========
+SOUNDS
+========
+
+================
+COLLISIONLAYERS
+================
+
+Background
+Target
+Player, Wall, Crate
+
+=====
+RULES
+=====
+
+[ player ] -> [ crate ]
+[ crate ] -> [ stationary target ]
+
+=============
+WINCONDITIONS
+=============
+
+Some Player
+
+======
+LEVELS
+======
+
+P.C

--- a/src/tests/static_analysis_testdata/program_flow/wake-property-write.json
+++ b/src/tests/static_analysis_testdata/program_flow/wake-property-write.json
@@ -1,0 +1,13 @@
+{
+  "schema": "ps-static-analysis-testdata-v1",
+  "wakeEdges": [
+    {
+      "from_line": 63,
+      "from_text": "[ orphan1 ] -> [ stationary sibling1 ]",
+      "to_line": 64,
+      "to_text": "[ sibling1_or_sibling2 ] -> [ ]",
+      "reasons": ["object_presence"]
+    }
+  ],
+  "againRules": []
+}

--- a/src/tests/static_analysis_testdata/program_flow/wake-property-write.txt
+++ b/src/tests/static_analysis_testdata/program_flow/wake-property-write.txt
@@ -1,0 +1,76 @@
+title Static Analysis Program Flow Wake Property Write
+
+========
+OBJECTS
+========
+
+Background
+black
+
+Target
+yellow
+
+Player
+white
+
+Wall
+brown
+
+Crate
+orange
+
+Orphan1
+lightblue
+
+Sibling1
+purple
+
+Sibling2
+pink
+
+========
+LEGEND
+========
+
+. = Background
+T = Target
+P = Player
+# = Wall
+C = Crate
+O = Orphan1
+X = Sibling1
+Y = Sibling2
+Sibling1_or_Sibling2 = Sibling1 or Sibling2
+
+========
+SOUNDS
+========
+
+================
+COLLISIONLAYERS
+================
+
+Background
+Target
+Player, Wall, Crate
+Orphan1
+Sibling1, Sibling2
+
+=====
+RULES
+=====
+
+[ orphan1 ] -> [ stationary sibling1 ]
+[ sibling1_or_sibling2 ] -> [ ]
+
+=============
+WINCONDITIONS
+=============
+
+Some Player
+
+======
+LEVELS
+======
+
+POXY

--- a/src/tests/static_analysis_testdata/program_flow/wake-self-loop.json
+++ b/src/tests/static_analysis_testdata/program_flow/wake-self-loop.json
@@ -1,0 +1,13 @@
+{
+  "schema": "ps-static-analysis-testdata-v1",
+  "wakeEdges": [
+    {
+      "from_line": 61,
+      "from_text": "right [ alpha | no alpha ] -> [ alpha | alpha ]",
+      "to_line": 61,
+      "to_text": "right [ alpha | no alpha ] -> [ alpha | alpha ]",
+      "reasons": ["object_presence"]
+    }
+  ],
+  "againRules": []
+}

--- a/src/tests/static_analysis_testdata/program_flow/wake-self-loop.txt
+++ b/src/tests/static_analysis_testdata/program_flow/wake-self-loop.txt
@@ -1,0 +1,73 @@
+title Static Analysis Program Flow Wake Self Loop
+
+========
+OBJECTS
+========
+
+Background
+black
+
+Target
+yellow
+
+Player
+white
+
+Wall
+brown
+
+Crate
+orange
+
+Alpha
+red
+
+Beta
+blue
+
+Gamma
+green
+
+========
+LEGEND
+========
+
+. = Background
+T = Target
+P = Player
+# = Wall
+C = Crate
+A = Alpha
+B = Beta
+G = Gamma
+
+========
+SOUNDS
+========
+
+================
+COLLISIONLAYERS
+================
+
+Background
+Target
+Player, Wall, Crate
+Alpha, Beta, Gamma
+
+=====
+RULES
+=====
+
+right [ alpha | no alpha ] -> [ alpha | alpha ]
+
+=============
+WINCONDITIONS
+=============
+
+Some Player
+
+======
+LEVELS
+======
+
+PA..

--- a/src/tests/static_analysis_testdata/wincondition_tags/all-on-target.json
+++ b/src/tests/static_analysis_testdata/wincondition_tags/all-on-target.json
@@ -1,0 +1,15 @@
+{
+  "schema": "ps-static-analysis-testdata-v1",
+  "winConditionTag": [
+    {
+      "line": 50,
+      "text": "All Crate on Target",
+      "tags": {
+        "objects_matched": ["Crate", "Target"],
+        "subjects_matched": ["Crate"],
+        "targets_matched": ["Target"],
+        "object_absences_matched": []
+      }
+    }
+  ]
+}

--- a/src/tests/static_analysis_testdata/wincondition_tags/all-on-target.txt
+++ b/src/tests/static_analysis_testdata/wincondition_tags/all-on-target.txt
@@ -1,0 +1,56 @@
+title Static Analysis Wincondition Tags All On Target
+
+========
+OBJECTS
+========
+
+Background
+black
+
+Target
+yellow
+
+Player
+white
+
+Crate
+orange
+
+========
+LEGEND
+========
+
+. = Background
+T = Target
+P = Player
+C = Crate
+
+========
+SOUNDS
+========
+
+================
+COLLISIONLAYERS
+================
+
+Background
+Target
+Player, Crate
+
+=====
+RULES
+=====
+
+[ player ] -> [ stationary player ]
+
+=============
+WINCONDITIONS
+=============
+
+All Crate on Target
+
+======
+LEVELS
+======
+
+PC.T

--- a/src/tests/static_analysis_testdata/wincondition_tags/multiple-mixed.json
+++ b/src/tests/static_analysis_testdata/wincondition_tags/multiple-mixed.json
@@ -1,0 +1,35 @@
+{
+  "schema": "ps-static-analysis-testdata-v1",
+  "winConditionTag": [
+    {
+      "line": 55,
+      "text": "Some Player",
+      "tags": {
+        "objects_matched": ["Player"],
+        "subjects_matched": ["Player"],
+        "targets_matched": [],
+        "object_absences_matched": []
+      }
+    },
+    {
+      "line": 56,
+      "text": "All Crate on Target",
+      "tags": {
+        "objects_matched": ["Crate", "Target"],
+        "subjects_matched": ["Crate"],
+        "targets_matched": ["Target"],
+        "object_absences_matched": []
+      }
+    },
+    {
+      "line": 57,
+      "text": "No Orphan1",
+      "tags": {
+        "objects_matched": ["Orphan1"],
+        "subjects_matched": [],
+        "targets_matched": [],
+        "object_absences_matched": ["Orphan1"]
+      }
+    }
+  ]
+}

--- a/src/tests/static_analysis_testdata/wincondition_tags/multiple-mixed.txt
+++ b/src/tests/static_analysis_testdata/wincondition_tags/multiple-mixed.txt
@@ -1,0 +1,63 @@
+title Static Analysis Wincondition Tags Multiple Mixed
+
+========
+OBJECTS
+========
+
+Background
+black
+
+Target
+yellow
+
+Player
+white
+
+Crate
+orange
+
+Orphan1
+lightblue
+
+========
+LEGEND
+========
+
+. = Background
+T = Target
+P = Player
+C = Crate
+O = Orphan1
+
+========
+SOUNDS
+========
+
+================
+COLLISIONLAYERS
+================
+
+Background
+Target
+Player, Crate
+Orphan1
+
+=====
+RULES
+=====
+
+[ player ] -> [ stationary player ]
+
+=============
+WINCONDITIONS
+=============
+
+Some Player
+All Crate on Target
+No Orphan1
+
+======
+LEVELS
+======
+
+PCT.O

--- a/src/tests/static_analysis_testdata/wincondition_tags/no-on-target.json
+++ b/src/tests/static_analysis_testdata/wincondition_tags/no-on-target.json
@@ -1,0 +1,15 @@
+{
+  "schema": "ps-static-analysis-testdata-v1",
+  "winConditionTag": [
+    {
+      "line": 50,
+      "text": "No Crate on Target",
+      "tags": {
+        "objects_matched": ["Crate", "Target"],
+        "subjects_matched": [],
+        "targets_matched": ["Target"],
+        "object_absences_matched": ["Crate"]
+      }
+    }
+  ]
+}

--- a/src/tests/static_analysis_testdata/wincondition_tags/no-on-target.json
+++ b/src/tests/static_analysis_testdata/wincondition_tags/no-on-target.json
@@ -5,9 +5,9 @@
       "line": 50,
       "text": "No Crate on Target",
       "tags": {
-        "objects_matched": ["Crate", "Target"],
+        "objects_matched": ["Crate"],
         "subjects_matched": [],
-        "targets_matched": ["Target"],
+        "targets_matched": [],
         "object_absences_matched": ["Crate"]
       }
     }

--- a/src/tests/static_analysis_testdata/wincondition_tags/no-on-target.txt
+++ b/src/tests/static_analysis_testdata/wincondition_tags/no-on-target.txt
@@ -1,0 +1,56 @@
+title Static Analysis Wincondition Tags No On Target
+
+========
+OBJECTS
+========
+
+Background
+black
+
+Target
+yellow
+
+Player
+white
+
+Crate
+orange
+
+========
+LEGEND
+========
+
+. = Background
+T = Target
+P = Player
+C = Crate
+
+========
+SOUNDS
+========
+
+================
+COLLISIONLAYERS
+================
+
+Background
+Target
+Player, Crate
+
+=====
+RULES
+=====
+
+[ player ] -> [ stationary player ]
+
+=============
+WINCONDITIONS
+=============
+
+No Crate on Target
+
+======
+LEVELS
+======
+
+P..T

--- a/src/tests/static_analysis_testdata/wincondition_tags/no-single.json
+++ b/src/tests/static_analysis_testdata/wincondition_tags/no-single.json
@@ -1,0 +1,15 @@
+{
+  "schema": "ps-static-analysis-testdata-v1",
+  "winConditionTag": [
+    {
+      "line": 45,
+      "text": "No Crate",
+      "tags": {
+        "objects_matched": ["Crate"],
+        "subjects_matched": [],
+        "targets_matched": [],
+        "object_absences_matched": ["Crate"]
+      }
+    }
+  ]
+}

--- a/src/tests/static_analysis_testdata/wincondition_tags/no-single.txt
+++ b/src/tests/static_analysis_testdata/wincondition_tags/no-single.txt
@@ -1,0 +1,51 @@
+title Static Analysis Wincondition Tags No Single
+
+========
+OBJECTS
+========
+
+Background
+black
+
+Player
+white
+
+Crate
+orange
+
+========
+LEGEND
+========
+
+. = Background
+P = Player
+C = Crate
+
+========
+SOUNDS
+========
+
+================
+COLLISIONLAYERS
+================
+
+Background
+Player, Crate
+
+=====
+RULES
+=====
+
+[ player ] -> [ stationary player ]
+
+=============
+WINCONDITIONS
+=============
+
+No Crate
+
+======
+LEVELS
+======
+
+P..

--- a/src/tests/static_analysis_testdata/wincondition_tags/property-subject.json
+++ b/src/tests/static_analysis_testdata/wincondition_tags/property-subject.json
@@ -1,0 +1,15 @@
+{
+  "schema": "ps-static-analysis-testdata-v1",
+  "winConditionTag": [
+    {
+      "line": 51,
+      "text": "Some Sibling1_or_Sibling2",
+      "tags": {
+        "objects_matched": ["Sibling1", "Sibling2"],
+        "subjects_matched": ["Sibling1", "Sibling2"],
+        "targets_matched": [],
+        "object_absences_matched": []
+      }
+    }
+  ]
+}

--- a/src/tests/static_analysis_testdata/wincondition_tags/property-subject.txt
+++ b/src/tests/static_analysis_testdata/wincondition_tags/property-subject.txt
@@ -1,0 +1,57 @@
+title Static Analysis Wincondition Tags Property Subject
+
+========
+OBJECTS
+========
+
+Background
+black
+
+Player
+white
+
+Sibling1
+red
+
+Sibling2
+blue
+
+========
+LEGEND
+========
+
+. = Background
+P = Player
+A = Sibling1
+B = Sibling2
+Sibling1_or_Sibling2 = Sibling1 or Sibling2
+
+========
+SOUNDS
+========
+
+================
+COLLISIONLAYERS
+================
+
+Background
+Player
+Sibling1, Sibling2
+
+=====
+RULES
+=====
+
+[ player ] -> [ stationary player ]
+
+=============
+WINCONDITIONS
+=============
+
+Some Sibling1_or_Sibling2
+
+======
+LEVELS
+======
+
+PA.

--- a/src/tests/static_analysis_testdata/wincondition_tags/property-target.json
+++ b/src/tests/static_analysis_testdata/wincondition_tags/property-target.json
@@ -1,0 +1,15 @@
+{
+  "schema": "ps-static-analysis-testdata-v1",
+  "winConditionTag": [
+    {
+      "line": 55,
+      "text": "All Crate on Sibling1_or_Sibling2",
+      "tags": {
+        "objects_matched": ["Crate", "Sibling1", "Sibling2"],
+        "subjects_matched": ["Crate"],
+        "targets_matched": ["Sibling1", "Sibling2"],
+        "object_absences_matched": []
+      }
+    }
+  ]
+}

--- a/src/tests/static_analysis_testdata/wincondition_tags/property-target.txt
+++ b/src/tests/static_analysis_testdata/wincondition_tags/property-target.txt
@@ -1,0 +1,61 @@
+title Static Analysis Wincondition Tags Property Target
+
+========
+OBJECTS
+========
+
+Background
+black
+
+Player
+white
+
+Crate
+orange
+
+Sibling1
+red
+
+Sibling2
+blue
+
+========
+LEGEND
+========
+
+. = Background
+P = Player
+C = Crate
+A = Sibling1
+B = Sibling2
+Sibling1_or_Sibling2 = Sibling1 or Sibling2
+
+========
+SOUNDS
+========
+
+================
+COLLISIONLAYERS
+================
+
+Background
+Sibling1, Sibling2
+Player, Crate
+
+=====
+RULES
+=====
+
+[ player ] -> [ stationary player ]
+
+=============
+WINCONDITIONS
+=============
+
+All Crate on Sibling1_or_Sibling2
+
+======
+LEVELS
+======
+
+PCA.

--- a/src/tests/static_analysis_testdata/wincondition_tags/some-on-target.json
+++ b/src/tests/static_analysis_testdata/wincondition_tags/some-on-target.json
@@ -1,0 +1,15 @@
+{
+  "schema": "ps-static-analysis-testdata-v1",
+  "winConditionTag": [
+    {
+      "line": 46,
+      "text": "Some Player on Target",
+      "tags": {
+        "objects_matched": ["Player", "Target"],
+        "subjects_matched": ["Player"],
+        "targets_matched": ["Target"],
+        "object_absences_matched": []
+      }
+    }
+  ]
+}

--- a/src/tests/static_analysis_testdata/wincondition_tags/some-on-target.txt
+++ b/src/tests/static_analysis_testdata/wincondition_tags/some-on-target.txt
@@ -1,0 +1,52 @@
+title Static Analysis Wincondition Tags Some On Target
+
+========
+OBJECTS
+========
+
+Background
+black
+
+Target
+yellow
+
+Player
+white
+
+========
+LEGEND
+========
+
+. = Background
+T = Target
+P = Player
+
+========
+SOUNDS
+========
+
+================
+COLLISIONLAYERS
+================
+
+Background
+Target
+Player
+
+=====
+RULES
+=====
+
+[ player ] -> [ stationary player ]
+
+=============
+WINCONDITIONS
+=============
+
+Some Player on Target
+
+======
+LEVELS
+======
+
+P..

--- a/src/tests/static_analysis_testdata/wincondition_tags/some-single.json
+++ b/src/tests/static_analysis_testdata/wincondition_tags/some-single.json
@@ -1,0 +1,15 @@
+{
+  "schema": "ps-static-analysis-testdata-v1",
+  "winConditionTag": [
+    {
+      "line": 41,
+      "text": "Some Player",
+      "tags": {
+        "objects_matched": ["Player"],
+        "subjects_matched": ["Player"],
+        "targets_matched": [],
+        "object_absences_matched": []
+      }
+    }
+  ]
+}

--- a/src/tests/static_analysis_testdata/wincondition_tags/some-single.txt
+++ b/src/tests/static_analysis_testdata/wincondition_tags/some-single.txt
@@ -1,0 +1,47 @@
+title Static Analysis Wincondition Tags Some Single
+
+========
+OBJECTS
+========
+
+Background
+black
+
+Player
+white
+
+========
+LEGEND
+========
+
+. = Background
+P = Player
+
+========
+SOUNDS
+========
+
+================
+COLLISIONLAYERS
+================
+
+Background
+Player
+
+=====
+RULES
+=====
+
+[ player ] -> [ stationary player ]
+
+=============
+WINCONDITIONS
+=============
+
+Some Player
+
+======
+LEVELS
+======
+
+P..

--- a/src/tests/static_analysis_testdata_runner.js
+++ b/src/tests/static_analysis_testdata_runner.js
@@ -535,6 +535,102 @@ function runProgramFlowDir(dirPath, log = process.stdout.write.bind(process.stdo
     }
 }
 
+function allWinConditionRecords(report, source) {
+    const sourceLines = source.split(/\r?\n/);
+    return (report.ps_tagged && report.ps_tagged.winconditions || []).map(wincondition => {
+        const text = (sourceLines[(wincondition.source_line || 1) - 1] || '').trim();
+        return { wincondition, line: wincondition.source_line, text };
+    });
+}
+
+function winConditionClaimByName(claimDescriptions, tagName) {
+    return (claimDescriptions.winConditionTags || []).find(tag => tag.name === tagName) || null;
+}
+
+function deriveWinConditionTagValue(wincondition, tagName) {
+    const value = wincondition.tags ? wincondition.tags[tagName] : undefined;
+    return Array.isArray(value) ? value.slice() : [];
+}
+
+function buildWinConditionTagExpectations(source, report, claimDescriptions) {
+    const winConditionTags = claimDescriptions.winConditionTags || [];
+    const records = allWinConditionRecords(report, source);
+    return {
+        schema: FIXTURE_SCHEMA,
+        winConditionTag: records.map(record => ({
+            line: record.line,
+            text: record.text,
+            tags: Object.fromEntries(winConditionTags.map(tag => [
+                tag.name,
+                deriveWinConditionTagValue(record.wincondition, tag.name),
+            ])),
+        })),
+    };
+}
+
+function validateWinConditionTagExpectationShape(filePath, payload) {
+    assert.strictEqual(payload.schema, FIXTURE_SCHEMA, `${filePath}: unsupported fixture schema`);
+    assert.ok(Array.isArray(payload.winConditionTag), `${filePath}: winConditionTag must be an array`);
+    for (const [index, item] of payload.winConditionTag.entries()) {
+        assert.ok(item && typeof item === 'object' && !Array.isArray(item), `${filePath}: winConditionTag[${index}] must be an object`);
+        assert.ok(Number.isInteger(item.line) && item.line > 0, `${filePath}: winConditionTag[${index}] missing positive integer line`);
+        assert.ok(typeof item.text === 'string' && item.text.length > 0, `${filePath}: winConditionTag[${index}] missing text`);
+        assert.ok(item.tags && typeof item.tags === 'object' && !Array.isArray(item.tags), `${filePath}: winConditionTag[${index}] missing tags object`);
+    }
+}
+
+function findWinConditionRecord(filePath, records, expected) {
+    const matches = records.filter(record => record.line === expected.line && record.text === expected.text);
+    if (matches.length !== 1) {
+        assert.fail(`${filePath}: winConditionTag line ${expected.line} text ${JSON.stringify(expected.text)} matched ${matches.length} analyzed win conditions; expected exactly 1`);
+    }
+    return matches[0];
+}
+
+function checkWinConditionFixture(txtPath, jsonPath, claimDescriptions) {
+    const source = fs.readFileSync(txtPath, 'utf8');
+    const report = analyzeSource(source, { sourcePath: txtPath });
+    assert.strictEqual(report.status, 'ok', `${txtPath}: static analysis status ${report.status}`);
+    const payload = readJson(jsonPath);
+    validateWinConditionTagExpectationShape(jsonPath, payload);
+    const records = allWinConditionRecords(report, source);
+    for (const row of payload.winConditionTag) {
+        const record = findWinConditionRecord(jsonPath, records, row);
+        for (const tagName of Object.keys(row.tags)) {
+            const claim = winConditionClaimByName(claimDescriptions, tagName);
+            assert.ok(claim, `${jsonPath}: unknown win condition tag ${tagName}`);
+            assertStringArray(jsonPath, tagName, row.tags[tagName]);
+            const actual = deriveWinConditionTagValue(record.wincondition, tagName);
+            assertSameStringSet(jsonPath, `winConditionTag line ${record.line} ${record.text} ${tagName}`, row.tags[tagName], actual);
+        }
+    }
+}
+
+function runWinConditionTagsDir(dirPath, claimDescriptions, log = process.stdout.write.bind(process.stdout)) {
+    const txtFiles = sortedFiles(dirPath, '.txt');
+    const jsonFiles = sortedFiles(dirPath, '.json');
+    const txtStems = new Set(txtFiles.map(name => path.basename(name, '.txt')));
+    const jsonStems = new Set(jsonFiles.map(name => path.basename(name, '.json')));
+
+    for (const stem of jsonStems) {
+        assert.ok(txtStems.has(stem), `${path.join(dirPath, `${stem}.json`)}: missing matching .txt`);
+    }
+
+    for (const txtName of txtFiles) {
+        const stem = path.basename(txtName, '.txt');
+        const txtPath = path.join(dirPath, txtName);
+        const jsonPath = path.join(dirPath, `${stem}.json`);
+        if (!fs.existsSync(jsonPath)) {
+            const source = fs.readFileSync(txtPath, 'utf8');
+            const report = analyzeSource(source, { sourcePath: txtPath });
+            assert.strictEqual(report.status, 'ok', `${txtPath}: static analysis status ${report.status}`);
+            writeJson(jsonPath, buildWinConditionTagExpectations(source, report, claimDescriptions));
+            log(`generated static analysis testdata: wincondition_tags/${stem}.json (review before committing)\n`);
+        }
+        checkWinConditionFixture(txtPath, jsonPath, claimDescriptions);
+    }
+}
+
 function runStaticAnalysisTestdata(options = {}) {
     const root = options.root || TESTDATA_ROOT;
     const claimDescriptions = loadClaimDescriptions(options.claimDescriptionsPath || CLAIM_DESCRIPTIONS_PATH);
@@ -547,6 +643,9 @@ function runStaticAnalysisTestdata(options = {}) {
     const programFlowDir = path.join(root, 'program_flow');
     assert.ok(fs.existsSync(programFlowDir), `${programFlowDir}: missing program_flow testdata directory`);
     runProgramFlowDir(programFlowDir, options.log);
+    const winConditionTagsDir = path.join(root, 'wincondition_tags');
+    assert.ok(fs.existsSync(winConditionTagsDir), `${winConditionTagsDir}: missing wincondition_tags testdata directory`);
+    runWinConditionTagsDir(winConditionTagsDir, claimDescriptions, options.log);
     process.stdout.write('static_analysis_testdata_runner: ok\n');
 }
 
@@ -558,13 +657,17 @@ module.exports = {
     buildObjectTagExpectations,
     buildProgramFlowExpectations,
     buildRuleTagExpectations,
+    buildWinConditionTagExpectations,
     deriveObjectTagValue,
     deriveRuleTagValue,
+    deriveWinConditionTagValue,
     findRuleRecord,
+    findWinConditionRecord,
     formatFixtureJson,
     loadClaimDescriptions,
     runObjectTagsDir,
     runProgramFlowDir,
     runRuleTagsDir,
     runStaticAnalysisTestdata,
+    runWinConditionTagsDir,
 };

--- a/src/tests/static_analysis_testdata_runner.js
+++ b/src/tests/static_analysis_testdata_runner.js
@@ -69,6 +69,7 @@ function loadClaimDescriptions(filePath = CLAIM_DESCRIPTIONS_PATH) {
     assert.strictEqual(claims.schema, 'ps-static-analysis-claim-descriptions-v1', `${filePath}: unsupported claim-description schema`);
     validateClaimDescriptionList(filePath, 'objectTags', claims.objectTags);
     validateClaimDescriptionList(filePath, 'ruleTags', claims.ruleTags);
+    validateClaimDescriptionList(filePath, 'factFamilies', claims.factFamilies);
     return claims;
 }
 
@@ -229,9 +230,18 @@ function ruleHasMultipleCells(rule) {
     return rule.lhs.concat(rule.rhs).some(row => row.length > 1);
 }
 
+function renderRuleCommands(rule) {
+    return (rule.commands || [])
+        .map(command => command.join(' '))
+        .join(' ');
+}
+
 function renderRuleText(rule) {
+    const lateMark = rule.late ? 'late ' : '';
     const prefix = ruleHasMultipleCells(rule) ? `${rule.direction} ` : '';
-    return `${prefix}${renderRuleSide(rule.lhs)} -> ${renderRuleSide(rule.rhs)}`;
+    const body = `${lateMark}${prefix}${renderRuleSide(rule.lhs)} -> ${renderRuleSide(rule.rhs)}`;
+    const suffix = renderRuleCommands(rule);
+    return suffix.length > 0 ? `${body} ${suffix}` : body;
 }
 
 function allRuleRecords(report, source) {
@@ -349,6 +359,101 @@ function checkRuleFixture(txtPath, jsonPath, claimDescriptions) {
     }
 }
 
+const REASON_VALUES = ['object_presence', 'object_absence', 'movement'];
+
+function recordById(records) {
+    const byId = new Map();
+    for (const record of records) {
+        byId.set(record.rule.id, record);
+    }
+    return byId;
+}
+
+function compareEdgeRows(a, b) {
+    if (a.from_line !== b.from_line) return a.from_line - b.from_line;
+    if (a.from_text !== b.from_text) return a.from_text.localeCompare(b.from_text);
+    if (a.to_line !== b.to_line) return a.to_line - b.to_line;
+    return a.to_text.localeCompare(b.to_text);
+}
+
+function compareAgainRows(a, b) {
+    if (a.line !== b.line) return a.line - b.line;
+    return a.text.localeCompare(b.text);
+}
+
+function programFlowFactValue(report) {
+    const facts = (report.facts && report.facts.program_flow) || [];
+    if (facts.length === 0) return { rule_ids: [], wake_edges: [], again_rules: [], tick_restart_possible: false };
+    return facts[0].value;
+}
+
+function buildProgramFlowExpectations(source, report) {
+    const records = allRuleRecords(report, source);
+    assertRuleRecordsIdempotent(report.source.path, records);
+    const byId = recordById(records);
+    const value = programFlowFactValue(report);
+    const wakeEdges = value.wake_edges.map(edge => {
+        const from = byId.get(edge.from);
+        const to = byId.get(edge.to);
+        assert.ok(from, `program_flow edge from rule id ${edge.from} not found in records`);
+        assert.ok(to, `program_flow edge to rule id ${edge.to} not found in records`);
+        return {
+            from_line: from.line,
+            from_text: from.text,
+            to_line: to.line,
+            to_text: to.text,
+            reasons: edge.reasons.slice(),
+        };
+    });
+    wakeEdges.sort(compareEdgeRows);
+    const againRules = value.again_rules.map(ruleId => {
+        const record = byId.get(ruleId);
+        assert.ok(record, `program_flow again rule id ${ruleId} not found in records`);
+        return { line: record.line, text: record.text };
+    });
+    againRules.sort(compareAgainRows);
+    return {
+        schema: FIXTURE_SCHEMA,
+        wakeEdges,
+        againRules,
+    };
+}
+
+function validateProgramFlowExpectationShape(filePath, payload) {
+    assert.strictEqual(payload.schema, FIXTURE_SCHEMA, `${filePath}: unsupported fixture schema`);
+    assert.ok(Array.isArray(payload.wakeEdges), `${filePath}: wakeEdges must be an array`);
+    assert.ok(Array.isArray(payload.againRules), `${filePath}: againRules must be an array`);
+    for (const [index, edge] of payload.wakeEdges.entries()) {
+        assert.ok(edge && typeof edge === 'object' && !Array.isArray(edge), `${filePath}: wakeEdges[${index}] must be an object`);
+        assert.ok(Number.isInteger(edge.from_line) && edge.from_line > 0, `${filePath}: wakeEdges[${index}] missing positive integer from_line`);
+        assert.ok(typeof edge.from_text === 'string' && edge.from_text.length > 0, `${filePath}: wakeEdges[${index}] missing from_text`);
+        assert.ok(Number.isInteger(edge.to_line) && edge.to_line > 0, `${filePath}: wakeEdges[${index}] missing positive integer to_line`);
+        assert.ok(typeof edge.to_text === 'string' && edge.to_text.length > 0, `${filePath}: wakeEdges[${index}] missing to_text`);
+        assert.ok(Array.isArray(edge.reasons) && edge.reasons.length > 0, `${filePath}: wakeEdges[${index}].reasons must be a non-empty array`);
+        for (const reason of edge.reasons) {
+            assert.ok(REASON_VALUES.includes(reason), `${filePath}: wakeEdges[${index}].reasons contains unknown reason ${JSON.stringify(reason)}`);
+        }
+    }
+    for (const [index, row] of payload.againRules.entries()) {
+        assert.ok(row && typeof row === 'object' && !Array.isArray(row), `${filePath}: againRules[${index}] must be an object`);
+        assert.ok(Number.isInteger(row.line) && row.line > 0, `${filePath}: againRules[${index}] missing positive integer line`);
+        assert.ok(typeof row.text === 'string' && row.text.length > 0, `${filePath}: againRules[${index}] missing text`);
+    }
+}
+
+function checkProgramFlowFixture(txtPath, jsonPath) {
+    const source = fs.readFileSync(txtPath, 'utf8');
+    const report = analyzeSource(source, { sourcePath: txtPath });
+    assert.strictEqual(report.status, 'ok', `${txtPath}: static analysis status ${report.status}`);
+    const payload = readJson(jsonPath);
+    validateProgramFlowExpectationShape(jsonPath, payload);
+    const actual = buildProgramFlowExpectations(source, report);
+    const expectedEdges = payload.wakeEdges.slice().sort(compareEdgeRows);
+    const expectedAgain = payload.againRules.slice().sort(compareAgainRows);
+    assert.deepStrictEqual(actual.wakeEdges, expectedEdges, `${jsonPath}: wakeEdges mismatch`);
+    assert.deepStrictEqual(actual.againRules, expectedAgain, `${jsonPath}: againRules mismatch`);
+}
+
 function sortedFiles(dirPath, ext) {
     return fs.readdirSync(dirPath)
         .filter(name => name.endsWith(ext))
@@ -405,6 +510,31 @@ function runRuleTagsDir(dirPath, claimDescriptions, log = process.stdout.write.b
     }
 }
 
+function runProgramFlowDir(dirPath, log = process.stdout.write.bind(process.stdout)) {
+    const txtFiles = sortedFiles(dirPath, '.txt');
+    const jsonFiles = sortedFiles(dirPath, '.json');
+    const txtStems = new Set(txtFiles.map(name => path.basename(name, '.txt')));
+    const jsonStems = new Set(jsonFiles.map(name => path.basename(name, '.json')));
+
+    for (const stem of jsonStems) {
+        assert.ok(txtStems.has(stem), `${path.join(dirPath, `${stem}.json`)}: missing matching .txt`);
+    }
+
+    for (const txtName of txtFiles) {
+        const stem = path.basename(txtName, '.txt');
+        const txtPath = path.join(dirPath, txtName);
+        const jsonPath = path.join(dirPath, `${stem}.json`);
+        if (!fs.existsSync(jsonPath)) {
+            const source = fs.readFileSync(txtPath, 'utf8');
+            const report = analyzeSource(source, { sourcePath: txtPath });
+            assert.strictEqual(report.status, 'ok', `${txtPath}: static analysis status ${report.status}`);
+            writeJson(jsonPath, buildProgramFlowExpectations(source, report));
+            log(`generated static analysis testdata: program_flow/${stem}.json (review before committing)\n`);
+        }
+        checkProgramFlowFixture(txtPath, jsonPath);
+    }
+}
+
 function runStaticAnalysisTestdata(options = {}) {
     const root = options.root || TESTDATA_ROOT;
     const claimDescriptions = loadClaimDescriptions(options.claimDescriptionsPath || CLAIM_DESCRIPTIONS_PATH);
@@ -414,6 +544,9 @@ function runStaticAnalysisTestdata(options = {}) {
     const ruleTagsDir = path.join(root, 'rule_tags');
     assert.ok(fs.existsSync(ruleTagsDir), `${ruleTagsDir}: missing rule_tags testdata directory`);
     runRuleTagsDir(ruleTagsDir, claimDescriptions, options.log);
+    const programFlowDir = path.join(root, 'program_flow');
+    assert.ok(fs.existsSync(programFlowDir), `${programFlowDir}: missing program_flow testdata directory`);
+    runProgramFlowDir(programFlowDir, options.log);
     process.stdout.write('static_analysis_testdata_runner: ok\n');
 }
 
@@ -423,6 +556,7 @@ if (require.main === module) {
 
 module.exports = {
     buildObjectTagExpectations,
+    buildProgramFlowExpectations,
     buildRuleTagExpectations,
     deriveObjectTagValue,
     deriveRuleTagValue,
@@ -430,6 +564,7 @@ module.exports = {
     formatFixtureJson,
     loadClaimDescriptions,
     runObjectTagsDir,
+    runProgramFlowDir,
     runRuleTagsDir,
     runStaticAnalysisTestdata,
 };


### PR DESCRIPTION
$(cat <<'EOF'
## Summary

- **Program-flow wake graph** (`program_flow` fact): for every ordered pair of rules (R1, R2), determines whether R1's application could create a new match for R2. Emits `wake_edges` (with reasons: `object_presence`, `object_absence`, `movement`) and `again_rules` (rules that force a tick restart).
- **Win condition tags**: each win condition now emits four read-set tags — `objects_matched`, `subjects_matched`, `targets_matched`, `object_absences_matched` — mirroring the per-rule tag convention. For NO quantifier, only subjects appear in `object_absences_matched`; the "on Y" location qualifier is not tracked as a read.
- **Fixture test suite**: 9 program-flow fixtures covering all wake-graph branches (object presence/absence, movement, randomdir expansion, self-loops, cross-section edges, `again` rules, no-edges case). 8 win-condition-tag fixtures covering all quantifiers (SOME, ALL, NO), the two-mask form, OR-property expansion in both positions, and mixed quantifiers in a single source.
- **Renderer fix**: `renderRuleText` now emits `late ` prefix and trailing commands (e.g. `again`) so source↔canonical idempotency checks work correctly.

## Test plan

- [ ] `node src/tests/run_tests_node.js` — 742/742 pass
- [ ] `node src/tests/static_analysis_testdata_runner.js` — all fixture directories pass
- [ ] Hand-audit fixture JSONs: every wake edge corresponds to an actual write/read relationship in the source; every win condition tag array reflects the correct object expansion
EOF
)

---
_Generated by [Claude Code](https://claude.ai/code/session_013NEBGfRx1ioH4HxW2Wh3gW)_