### PR TITLE
[codex] Test temporary runtime contracts

### DIFF
--- a/src/tests/ps_static_analysis.js
+++ b/src/tests/ps_static_analysis.js
@@ -1778,7 +1778,11 @@ function factDerivers() {
 function deriveFacts(psTagged, familyFilter) {
     const derivers = factDerivers();
     if (familyFilter) {
-        return { [familyFilter]: derivers[familyFilter] ? derivers[familyFilter](psTagged) : [] };
+        const familyNames = Array.isArray(familyFilter) ? familyFilter : [familyFilter];
+        return Object.fromEntries(familyNames.map(family => [
+            family,
+            derivers[family] ? derivers[family](psTagged) : [],
+        ]));
     }
 
     return Object.fromEntries(Object.entries(derivers).map(([family, derive]) => [

--- a/src/tests/run_static_analysis_runtime_contracts_node.js
+++ b/src/tests/run_static_analysis_runtime_contracts_node.js
@@ -90,7 +90,7 @@ function staticContractForSource(source, testName) {
     const sourcePath = `testdata:${testName}`;
     const report = analyzeSource(source, {
         sourcePath,
-        familyFilter: 'count_layer_invariants',
+        familyFilter: ['count_layer_invariants', 'transient_boundary'],
     });
     if (report.status !== 'ok') {
         const expected = ANALYSIS_UNAVAILABLE_TESTS.get(testName);
@@ -108,6 +108,7 @@ function staticContractForSource(source, testName) {
             objectNames: [],
             constantQuantityObjectNames: [],
             quantityContracts: [],
+            temporaryObjectNames: [],
             unavailableReason: `${report.status}: ${expected.diagnostic}`,
         };
     }
@@ -128,6 +129,9 @@ function staticContractForSource(source, testName) {
             .filter(contract => contract.neverIncreases && contract.neverDecreases)
             .map(contract => contract.objectName),
         quantityContracts,
+        temporaryObjectNames: objects
+            .filter(object => object.tags && object.tags.temporary === true)
+            .map(object => object.name),
         unavailableReason: null,
     };
 }
@@ -253,6 +257,16 @@ function firstQuantityDifference(beforeCounts, quantityContracts) {
     return null;
 }
 
+function firstTemporaryPresence(objectNames) {
+    for (const objectName of objectNames) {
+        const count = objectCountSnapshot(objectName);
+        if (count !== 0) {
+            return { objectName, count };
+        }
+    }
+    return null;
+}
+
 function quantityClaimCount(quantityContracts) {
     let count = 0;
     for (const contract of quantityContracts) {
@@ -320,6 +334,7 @@ function runSimulationWithStaticChecks(testName, dataarray) {
     const staticObjects = staticContract.objectNames;
     const constantQuantityObjects = staticContract.constantQuantityObjectNames;
     const quantityContracts = staticContract.quantityContracts;
+    const temporaryObjects = staticContract.temporaryObjectNames;
     const countedObjects = quantityObjectNames(quantityContracts);
 
     const previousUnitTesting = unitTesting;
@@ -329,6 +344,7 @@ function runSimulationWithStaticChecks(testName, dataarray) {
 
     let objectBoundaryChecks = 0;
     let quantityBoundaryChecks = 0;
+    let temporaryBoundaryChecks = 0;
     let restartBoundaryTriggered = false;
     const previousDoRestart = global.DoRestart;
     if (typeof previousDoRestart === 'function') {
@@ -356,6 +372,19 @@ function runSimulationWithStaticChecks(testName, dataarray) {
                 || restartBoundaryTriggered
                 || !sameBoardIdentity(currentIdentity, nextIdentity)
                 || !canSnapshotBoard();
+
+            if (canSnapshotBoard()) {
+                const temporaryDiff = firstTemporaryPresence(temporaryObjects);
+                if (temporaryDiff) {
+                    throw new Error([
+                        `${testName}: temporary object survived stable boundary`,
+                        `  input ${inputIndex}: ${tokenLabel(inputToken)}`,
+                        `  object: ${temporaryDiff.objectName}`,
+                        `  count: ${temporaryDiff.count}`,
+                    ].join('\n'));
+                }
+                temporaryBoundaryChecks += temporaryObjects.length;
+            }
 
             if (resetBoundary) {
                 currentIdentity = nextIdentity;
@@ -399,8 +428,10 @@ function runSimulationWithStaticChecks(testName, dataarray) {
         return {
             staticObjectCount: staticObjects.length,
             constantQuantityObjectCount: constantQuantityObjects.length,
+            temporaryObjectCount: temporaryObjects.length,
             objectBoundaryChecks,
             quantityBoundaryChecks,
+            temporaryBoundaryChecks,
             analysisUnavailableReason: staticContract.unavailableReason,
         };
     } finally {
@@ -430,8 +461,10 @@ function runAll(options = {}) {
     let caseCount = 0;
     let casesWithStaticObjects = 0;
     let casesWithConstantQuantityObjects = 0;
+    let casesWithTemporaryObjects = 0;
     let objectBoundaryChecks = 0;
     let quantityBoundaryChecks = 0;
+    let temporaryBoundaryChecks = 0;
     let analysisUnavailableCount = 0;
     const entries = global.testdata.filter(entry => testMatchesFilter(entry[0], options.filter || null));
 
@@ -457,8 +490,12 @@ function runAll(options = {}) {
             if (result.constantQuantityObjectCount > 0) {
                 casesWithConstantQuantityObjects++;
             }
+            if (result.temporaryObjectCount > 0) {
+                casesWithTemporaryObjects++;
+            }
             objectBoundaryChecks += result.objectBoundaryChecks;
             quantityBoundaryChecks += result.quantityBoundaryChecks;
+            temporaryBoundaryChecks += result.temporaryBoundaryChecks;
             if (result.analysisUnavailableReason) {
                 analysisUnavailableCount++;
                 progressLog(options, `static_analysis_runtime_contracts:   static analysis unavailable: ${result.analysisUnavailableReason}`);
@@ -473,8 +510,10 @@ function runAll(options = {}) {
         caseCount,
         casesWithStaticObjects,
         casesWithConstantQuantityObjects,
+        casesWithTemporaryObjects,
         objectBoundaryChecks,
         quantityBoundaryChecks,
+        temporaryBoundaryChecks,
         analysisUnavailableCount,
         failures,
     };
@@ -497,7 +536,7 @@ function main() {
     }
 
     console.log(
-        `static_analysis_runtime_contracts: ok (${result.caseCount} cases, ${result.analysisUnavailableCount} analysis-unavailable, ${result.casesWithStaticObjects} with static objects, ${result.casesWithConstantQuantityObjects} with constant-quantity objects, ${result.objectBoundaryChecks} object-boundary checks, ${result.quantityBoundaryChecks} quantity-boundary checks)`
+        `static_analysis_runtime_contracts: ok (${result.caseCount} cases, ${result.analysisUnavailableCount} analysis-unavailable, ${result.casesWithStaticObjects} with static objects, ${result.casesWithConstantQuantityObjects} with constant-quantity objects, ${result.casesWithTemporaryObjects} with temporary objects, ${result.objectBoundaryChecks} object-boundary checks, ${result.quantityBoundaryChecks} quantity-boundary checks, ${result.temporaryBoundaryChecks} temporary-boundary checks)`
     );
     return 0;
 }
@@ -518,6 +557,7 @@ module.exports = {
     engineObjectName,
     firstQuantityDifference,
     firstSnapshotDifference,
+    firstTemporaryPresence,
     objectCountSnapshot,
     parseArgs,
     runAll,

--- a/src/tests/run_static_analysis_runtime_contracts_node_test.js
+++ b/src/tests/run_static_analysis_runtime_contracts_node_test.js
@@ -83,4 +83,68 @@ assert.ok(
     'semantic restart regression should exercise quantity contract checks before restart'
 );
 
+const temporaryBoundarySource = [
+    '========',
+    'OBJECTS',
+    '========',
+    '',
+    'Background',
+    'Black',
+    '',
+    'Player',
+    'Pink',
+    '',
+    'Spark',
+    'Yellow',
+    '',
+    '=======',
+    'LEGEND',
+    '=======',
+    '',
+    'P = Player',
+    '',
+    '======',
+    'SOUNDS',
+    '======',
+    '',
+    '================',
+    'COLLISIONLAYERS',
+    '================',
+    '',
+    'Background',
+    'Player',
+    'Spark',
+    '',
+    '======',
+    'RULES',
+    '======',
+    '',
+    '[ action Player ] -> [ Player Spark ]',
+    'late [ Spark ] -> []',
+    '',
+    '==============',
+    'WINCONDITIONS',
+    '==============',
+    '',
+    'Some Player',
+    '',
+    '=======',
+    'LEVELS',
+    '=======',
+    '',
+    'P',
+].join('\n');
+
+const temporaryBoundary = runSimulationWithStaticChecks('temporary boundary', [
+    temporaryBoundarySource,
+    [4],
+    'background player:0,\n',
+]);
+
+assert.strictEqual(temporaryBoundary.temporaryObjectCount, 1, 'temporary fixture should have one temporary object');
+assert.ok(
+    temporaryBoundary.temporaryBoundaryChecks > 0,
+    'temporary checks should run for temporary objects'
+);
+
 console.log('run_static_analysis_runtime_contracts_node_test: ok');


### PR DESCRIPTION
## Summary
- Add temporary-object contracts to the testdata.js runtime replay harness.
- Let the analyser derive count-layer and transient-boundary facts together for the runner.
- Fail replay checks when a proved-temporary object survives a stable post-turn boundary.

## Validation
- node src/tests/ps_static_analysis_node.js
- node src/tests/static_analysis_testdata_runner.js
- node src/tests/static_analysis_testdata_runner_node.js
- node src/tests/static_analysis_explorer_node.js
- node src/tests/solver_static_opt_node.js
- node src/tests/compare_solver_static_opt_runs_node.js
- node src/tests/run_static_analysis_runtime_contracts_node_test.js
- node src/tests/static_analysis_performance_node.js
- git diff --check
- node src/tests/run_static_analysis_runtime_contracts_node.js

Full runtime replay result: 469 cases, 16 analysis-unavailable, 447 with static objects, 450 with constant-quantity objects, 70 with temporary objects, 78247 object-boundary checks, 296000 quantity-boundary checks, 11996 temporary-boundary checks.