### PR TITLE
Quality: Missing URL.revokeObjectURL in FileSaver.js causes memory leak

### DIFF
--- a/src/js/FileSaver.js
+++ b/src/js/FileSaver.js
@@ -14,4 +14,6 @@ function saveAs(text, type, filename) {
     element.click();
 
     document.body.removeChild(element);
+
+    URL.revokeObjectURL(url);
 }


### PR DESCRIPTION
## Summary

Quality: Missing URL.revokeObjectURL in FileSaver.js causes memory leak

## Problem

**Severity**: `Medium` | **File**: `src/js/FileSaver.js:L4`

The saveAs function in FileSaver.js creates a Blob URL with URL.createObjectURL() but never revokes it with URL.revokeObjectURL(). This causes memory leaks, especially problematic if the function is called frequently to save files.

## Solution

Store the URL in a variable and revoke it after the download is triggered, or use a setTimeout to revoke after a short delay: `setTimeout(() => URL.revokeObjectURL(url), 0);`

## Changes

- `src/js/FileSaver.js` (modified)